### PR TITLE
Bug fixed

### DIFF
--- a/src/Media.js
+++ b/src/Media.js
@@ -339,7 +339,9 @@ class MediaPlayer extends Media {
       this.started = false;
       this.track = new MediaStreamTrack({ kind: "audio" });
       this.emit("finish");
-      res();
+      this.once("finish", () => {
+        res();
+      });
     });
   }
   sleep(ms) {


### PR DESCRIPTION
(double skip `this.emit("finish")`)
to
```js
     this.emit("finish");
      this.once("finish", () => {
        res();
      });
    });
  }
````