### PR TITLE
fix: import fs in Media.js

### DIFF
--- a/src/Media.js
+++ b/src/Media.js
@@ -1,4 +1,5 @@
 const { AudioSource, LocalAudioTrack, TrackPublishOptions, TrackSource, AudioFrame } = require("@livekit/rtc-node");
+const fs = require("fs");
 const ffmpeg = require("fluent-ffmpeg");
 const fPath = require("ffmpeg-static");
 const { EventEmitter } = require("events");


### PR DESCRIPTION
This imports "fs" module in Media.js to fix a crash in function PlayFile when trying to open a path to play it