### PR TITLE
fix: catch InvalidState error in playOutPacket captureFrame

### DIFF
--- a/src/Media.js
+++ b/src/Media.js
@@ -156,6 +156,10 @@ class MediaPlayer extends Media {
 			const c = this.chunks.shift();
 
 			this.volumeTransformer.once("data", async (chunk) => {
+				// Guard: if stop() was called while waiting for data,
+				// readyPlayPacket is false — discard this chunk silently.
+				if (!this.readyPlayPacket) return res();
+
 				const samples = new Int16Array(
 					chunk.buffer,
 					chunk.byteOffset,
@@ -166,10 +170,17 @@ class MediaPlayer extends Media {
 					this.SAMPLE_RATE,
 					this.CHANNELS,
 					Math.trunc(samples.length / this.CHANNELS)
-				)
+				);
 
-				await this.source.captureFrame(frame);
-				this.playedOutSamples += samples.length / this.CHANNELS;
+				try {
+					await this.source.captureFrame(frame);
+					this.playedOutSamples += samples.length / this.CHANNELS;
+				} catch (e) {
+					// AudioSource was closed or in InvalidState (track stopped mid-frame).
+					// Discard this frame silently and stop processing further chunks.
+					this.readyPlayPacket = true;
+					return res();
+				}
 
 				if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
 				this.readyPlayPacket = true;

--- a/src/Media.js
+++ b/src/Media.js
@@ -22,26 +22,26 @@ const RESUME_CHUNKS =  40; // resume FFmpeg output once buffer drains this low
  * @classdesc Basic class to process audio streams.
  */
 class Media extends EventEmitter {
-	SAMPLE_RATE = 48000;
-	CHANNELS = 2;
-	id = null;
+    SAMPLE_RATE = 48000;
+    CHANNELS = 2;
+    id = null;
 
-	constructor() {
-		super();
-		this.id = Math.random().toString(36) + Date.now();
-		this.source = new AudioSource(this.SAMPLE_RATE, this.CHANNELS);
-		this.track = LocalAudioTrack.createAudioTrack("audio-" + this.id, this.source);
-	}
+    constructor() {
+        super();
+        this.id = Math.random().toString(36) + Date.now();
+        this.source = new AudioSource(this.SAMPLE_RATE, this.CHANNELS);
+        this.track = LocalAudioTrack.createAudioTrack("audio-" + this.id, this.source);
+    }
 
-	playFile(path) {
-		if (!path) throw "You must specify a file to play!";
-		const stream = fs.createReadStream(path);
-		this.playStream(stream);
-	}
-	playStream(stream) {
-		if (!stream) throw "You must specify a stream to play!";
-		throw "Unsupported. Use MediaPlayer instead.";
-	}
+    playFile(path) {
+        if (!path) throw "You must specify a file to play!";
+        const stream = fs.createReadStream(path);
+        this.playStream(stream);
+    }
+    playStream(stream) {
+        if (!stream) throw "You must specify a stream to play!";
+        throw "Unsupported. Use MediaPlayer instead.";
+    }
 }
 
 /**
@@ -53,290 +53,296 @@ class Media extends EventEmitter {
  * @property {string} currTimestamp - Current timestamp as `hh:mm:ss`.
  */
 class MediaPlayer extends Media {
-	/**
-	 * @param {boolean} normalisation=true Whether to pass the `loudnorm` filter to FFmpeg.
-	 */
-	constructor(normalisation = true) {
-		super();
-		this.isMediaPlayer = true;
-		this.loudnessNormalisation = normalisation;
-		this.initValues();
-	}
+    /**
+     * @param {boolean} normalisation=true Whether to pass the `loudnorm` filter to FFmpeg.
+     */
+    constructor(normalisation = true) {
+        super();
+        this.isMediaPlayer = true;
+        this.loudnessNormalisation = normalisation;
+        this.initValues();
+    }
 
-	initValues() {
-		this.ready = true;
-		this.volCache = null;
+    initValues() {
+        this.ready = true;
+        this.volCache = null;
 
-		this.paused = false;
-		this.playing = false;
-		this.started = false;
-		// FIX: track stopped state so dangling volumeTransformer callbacks
-		// that fire after stop() don't try to capture frames on a dead player.
-		this.stopped = false;
+        this.paused = false;
+        this.playing = false;
+        this.started = false;
+        // FIX: track stopped state so dangling volumeTransformer callbacks
+        // that fire after stop() don't try to capture frames on a dead player.
+        this.stopped = false;
 
-		this.chunks = [];
-		this.readyPlayPacket = true;
-		this.ffmpegFinished = false;
-		this.playedOutSamples = 0;
-		this.codecData = null;
+        this.chunks = [];
+        this.readyPlayPacket = true;
+        this.ffmpegFinished = false;
+        this.playedOutSamples = 0;
+        this.codecData = null;
 
-		this.originStream = null;
-		this.fProc = null;
-		// FIX: store the ffmpeg output pipe so #cleanUp() can destroy it and
-		// free its internal buffer. In the original code this was a local
-		// variable inside playStream() and was unreachable from cleanup.
-		this._ffmpegOut = null;
+        this.originStream = null;
+        this.fProc = null;
+        // FIX: store the ffmpeg output pipe so #cleanUp() can destroy it and
+        // free its internal buffer. In the original code this was a local
+        // variable inside playStream() and was unreachable from cleanup.
+        this._ffmpegOut = null;
 
-		this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
-		this.volumeTransformer.once("data", () => {
-			this.playing = true;
-			this.emit("startplay");
-		});
-	}
+        this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
+        this.volumeTransformer.once("data", () => {
+            this.playing = true;
+            this.emit("startplay");
+        });
+    }
 
-	pause() {
-		if (this.paused) return;
-		this.paused = true;
-		// Also pause the FFmpeg output so we stop accumulating chunks while
-		// playback is suspended — without this the buffer keeps growing.
-		try { this._ffmpegOut?.pause(); } catch (_) {}
-		this.emit("pause");
-	}
+    pause() {
+        if (this.paused) return;
+        this.paused = true;
+        // Also pause the FFmpeg output so we stop accumulating chunks while
+        // playback is suspended — without this the buffer keeps growing.
+        try { this._ffmpegOut?.pause(); } catch (_) {}
+        this.emit("pause");
+    }
 
-	resume() {
-		if (!this.paused) return;
-		this.paused = false;
-		// Only resume FFmpeg output if the buffer has room.
-		if (this.chunks.length < RESUME_CHUNKS) {
-			try { this._ffmpegOut?.resume(); } catch (_) {}
-		}
-		if (this.readyPlayPacket) this.playOutPacket();
-		this.emit("unpause");
-	}
+    resume() {
+        if (!this.paused) return;
+        this.paused = false;
+        // Only resume FFmpeg output if the buffer has room.
+        if (this.chunks.length < RESUME_CHUNKS) {
+            try { this._ffmpegOut?.resume(); } catch (_) {}
+        }
+        if (this.readyPlayPacket) this.playOutPacket();
+        this.emit("unpause");
+    }
 
-	setVolume(v = 1) {
-		this.volCache = v;
-		return this.volumeTransformer.setVolume(v);
-	}
+    setVolume(v = 1) {
+        this.volCache = v;
+        return this.volumeTransformer.setVolume(v);
+    }
 
-	#cleanUp() {
-		// FIX: destroy the ffmpeg output stream first — this frees Node.js
-		// Readable buffer memory that was holding decoded PCM chunks.
-		try { this._ffmpegOut?.destroy(); } catch (_) {}
-		this._ffmpegOut = null;
+    #cleanUp() {
+        // FIX: destroy the ffmpeg output stream first — this frees Node.js
+        // Readable buffer memory that was holding decoded PCM chunks.
+        try { this._ffmpegOut?.destroy(); } catch (_) {}
+        this._ffmpegOut = null;
 
-		// Destroy the origin (input) stream so the HTTP connection closes.
-		try { this.originStream?.destroy(); } catch (_) {}
+        // Destroy the origin (input) stream so the HTTP connection closes.
+        try { this.originStream?.destroy(); } catch (_) {}
 
-		// FIX: original logic was `if (this.ffmpegFinished) this.fProc.kill()`
-		// which is backwards — it only killed ffmpeg when already done (a no-op)
-		// and left a live ffmpeg process running when stop() was called mid-stream.
-		// Correct: always kill if the process is still alive.
-		if (this.fProc) {
-			try { this.fProc.kill(); } catch (_) {}
-		}
+        // FIX: original logic was `if (this.ffmpegFinished) this.fProc.kill()`
+        // which is backwards — it only killed ffmpeg when already done (a no-op)
+        // and left a live ffmpeg process running when stop() was called mid-stream.
+        // Correct: always kill if the process is still alive.
+        if (this.fProc) {
+            try { this.fProc.kill(); } catch (_) {}
+        }
 
-		// Clear the chunks array so the PCM buffer is GC-eligible immediately.
-		this.chunks = [];
+        // Clear the chunks array so the PCM buffer is GC-eligible immediately.
+        this.chunks = [];
 
-		try { this.volumeTransformer.destroy(); } catch (_) {}
-	}
+        try { this.volumeTransformer.destroy(); } catch (_) {}
+    }
 
-	stop(init = true) {
-		this.stopped = true;
-		this.readyPlayPacket = false; // prevent new packets from being queued
-		this.#cleanUp();
-		if (init) this.initValues();
-		this.emit("finish");
-	}
+    stop(init = true) {
+        // Guard: if already stopped, don't re-emit "finish". Without this, the
+        // unconditional mediaPlayer.stop() call at the top of _doPlayNext fires
+        // a second "finish" event on an already-stopped player, which resolves
+        // the _streamViaRevoice promise for the *next* song before it plays
+        // a single frame — causing every song after the first to be skipped.
+        if (this.stopped && init) return;
+        this.stopped = true;
+        this.readyPlayPacket = false; // prevent new packets from being queued
+        this.#cleanUp();
+        if (init) this.initValues();
+        this.emit("finish");
+    }
 
-	destroy() {
-		return this.stop(false);
-	}
+    destroy() {
+        return this.stop(false);
+    }
 
-	get duration() {
-		return this.codecData?.duration || 0;
-	}
+    get duration() {
+        return this.codecData?.duration || 0;
+    }
 
-	get currTimestamp() {
-		// FIX: original called `this.seconds()` as a function but `seconds`
-		// is a getter — calling it as a function returned the getter function
-		// itself, making Math.floor(NaN) produce "NaN:NaN:NaN".
-		const sec_num = this.seconds;
-		var hours   = Math.floor(sec_num / 3600);
-		var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
-		var seconds = sec_num - (hours * 3600) - (minutes * 60);
-		if (hours   < 10) { hours   = "0" + hours;   }
-		if (minutes < 10) { minutes = "0" + minutes; }
-		if (seconds < 10) { seconds = "0" + seconds; }
-		return hours + ":" + minutes + ":" + seconds;
-	}
+    get currTimestamp() {
+        // FIX: original called `this.seconds()` as a function but `seconds`
+        // is a getter — calling it as a function returned the getter function
+        // itself, making Math.floor(NaN) produce "NaN:NaN:NaN".
+        const sec_num = this.seconds;
+        var hours   = Math.floor(sec_num / 3600);
+        var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
+        var seconds = sec_num - (hours * 3600) - (minutes * 60);
+        if (hours   < 10) { hours   = "0" + hours;   }
+        if (minutes < 10) { minutes = "0" + minutes; }
+        if (seconds < 10) { seconds = "0" + seconds; }
+        return hours + ":" + minutes + ":" + seconds;
+    }
 
-	get seconds() {
-		return this.playedOutSamples / this.SAMPLE_RATE;
-	}
+    get seconds() {
+        return this.playedOutSamples / this.SAMPLE_RATE;
+    }
 
-	get localAudioTrack() {
-		return this.track;
-	}
+    get localAudioTrack() {
+        return this.track;
+    }
 
-	get publishOptions() {
-		const options = new TrackPublishOptions();
-		options.source = TrackSource.SOURCE_MICROPHONE;
-		return options;
-	}
+    get publishOptions() {
+        const options = new TrackPublishOptions();
+        options.source = TrackSource.SOURCE_MICROPHONE;
+        return options;
+    }
 
-	async publishToRoom(room) {
-		await room.localParticipant.publishTrack(this.track, this.publishOptions);
-	}
+    async publishToRoom(room) {
+        await room.localParticipant.publishTrack(this.track, this.publishOptions);
+    }
 
-	async playOutPacket() {
-		return new Promise((res) => {
-			if (this.chunks.length === 0) return res(this.readyPlayPacket = true);
-			this.readyPlayPacket = false;
+    async playOutPacket() {
+        return new Promise((res) => {
+            if (this.chunks.length === 0) return res(this.readyPlayPacket = true);
+            this.readyPlayPacket = false;
 
-			const c = this.chunks.shift();
+            const c = this.chunks.shift();
 
-			this.volumeTransformer.once("data", async (chunk) => {
-				// FIX: guard against dangling promises. stop() destroys the
-				// volumeTransformer but a .once("data") listener added just
-				// before stop() fires can still execute here with stale data,
-				// creating an AudioFrame for a player that's already dead.
-				if (this.stopped) return res();
+            this.volumeTransformer.once("data", async (chunk) => {
+                // FIX: guard against dangling promises. stop() destroys the
+                // volumeTransformer but a .once("data") listener added just
+                // before stop() fires can still execute here with stale data,
+                // creating an AudioFrame for a player that's already dead.
+                if (this.stopped) return res();
 
-				const samples = new Int16Array(
-					chunk.buffer,
-					chunk.byteOffset,
-					chunk.length / 2 // chunk.length is in bytes
-				);
-				const frame = new AudioFrame(
-					samples,
-					this.SAMPLE_RATE,
-					this.CHANNELS,
-					Math.trunc(samples.length / this.CHANNELS)
-				);
+                const samples = new Int16Array(
+                    chunk.buffer,
+                    chunk.byteOffset,
+                    chunk.length / 2 // chunk.length is in bytes
+                );
+                const frame = new AudioFrame(
+                    samples,
+                    this.SAMPLE_RATE,
+                    this.CHANNELS,
+                    Math.trunc(samples.length / this.CHANNELS)
+                );
 
-				await this.source.captureFrame(frame);
-				this.playedOutSamples += samples.length / this.CHANNELS;
+                await this.source.captureFrame(frame);
+                this.playedOutSamples += samples.length / this.CHANNELS;
 
-				// BACKPRESSURE: resume FFmpeg output when the buffer drains
-				// below the low-water mark so it can refill the ~400 KB window.
-				if (
-					this._ffmpegOut &&
-					!this.paused &&
-					!this.ffmpegFinished &&
-					this.chunks.length < RESUME_CHUNKS
-				) {
-					try { this._ffmpegOut.resume(); } catch (_) {}
-				}
+                // BACKPRESSURE: resume FFmpeg output when the buffer drains
+                // below the low-water mark so it can refill the ~400 KB window.
+                if (
+                    this._ffmpegOut &&
+                    !this.paused &&
+                    !this.ffmpegFinished &&
+                    this.chunks.length < RESUME_CHUNKS
+                ) {
+                    try { this._ffmpegOut.resume(); } catch (_) {}
+                }
 
-				if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
-				this.readyPlayPacket = true;
-				if (this.chunks.length === 0 && this.ffmpegFinished) this.stop();
-				return res();
-			});
-			this.volumeTransformer.write(c);
-		});
-	}
+                if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
+                this.readyPlayPacket = true;
+                if (this.chunks.length === 0 && this.ffmpegFinished) this.stop();
+                return res();
+            });
+            this.volumeTransformer.write(c);
+        });
+    }
 
-	// FIX: accept the same `options` parameter that Player.mjs passes so it
-	// doesn't silently discard rawPcm / loudnorm overrides.
-	async playStream(stream, options = {}) {
-		this.emit("buffer");
-		this.originStream = stream;
-		this.started = false;
-		this.stopped = false;
-		this.ffmpegFinished = false;
-		this.playedOutSamples = 0;
+    // FIX: accept the same `options` parameter that Player.mjs passes so it
+    // doesn't silently discard rawPcm / loudnorm overrides.
+    async playStream(stream, options = {}) {
+        this.emit("buffer");
+        this.originStream = stream;
+        this.started = false;
+        this.stopped = false;
+        this.ffmpegFinished = false;
+        this.playedOutSamples = 0;
 
-		// When the caller signals rawPcm=true the stream is already decoded
-		// s16le PCM (e.g. NodeLink /v4/loadstream). Tell FFmpeg the format
-		// explicitly so it doesn't try to demux it as a container.
-		const isRawPcm = options.rawPcm === true;
+        // When the caller signals rawPcm=true the stream is already decoded
+        // s16le PCM (e.g. NodeLink /v4/loadstream). Tell FFmpeg the format
+        // explicitly so it doesn't try to demux it as a container.
+        const isRawPcm = options.rawPcm === true;
 
-		let fProc = ffmpeg(stream)
-			.noVideo()
-			.setFfmpegPath(fPath);
+        let fProc = ffmpeg(stream)
+            .noVideo()
+            .setFfmpegPath(fPath);
 
-		if (isRawPcm) {
-			fProc = fProc.inputOptions([
-				"-f s16le",
-				`-ar ${this.SAMPLE_RATE}`,
-				`-ac ${this.CHANNELS}`
-			]);
-		}
+        if (isRawPcm) {
+            fProc = fProc.inputOptions([
+                "-f s16le",
+                `-ar ${this.SAMPLE_RATE}`,
+                `-ac ${this.CHANNELS}`
+            ]);
+        }
 
-		fProc = fProc.outputOptions([
-			`-f s16le`,
-			`-ar ${this.SAMPLE_RATE}`,
-			`-ac ${this.CHANNELS}`
-		]);
+        fProc = fProc.outputOptions([
+            `-f s16le`,
+            `-ar ${this.SAMPLE_RATE}`,
+            `-ac ${this.CHANNELS}`
+        ]);
 
-		// Apply loudnorm unless explicitly disabled or the input is already raw PCM.
-		const useLoudnorm = isRawPcm ? false
-			: (options.loudnorm !== undefined ? options.loudnorm : this.loudnessNormalisation);
-		if (useLoudnorm) {
-			fProc = fProc.audioFilters("loudnorm");
-		}
+        // Apply loudnorm unless explicitly disabled or the input is already raw PCM.
+        const useLoudnorm = isRawPcm ? false
+            : (options.loudnorm !== undefined ? options.loudnorm : this.loudnessNormalisation);
+        if (useLoudnorm) {
+            fProc = fProc.audioFilters("loudnorm");
+        }
 
-		fProc
-			.on("start", (cli) => {
-				// Keep the start log — it's the only way to see the exact FFmpeg
-				// command line when diagnosing "Invalid data" errors.
-				console.log("[MediaPlayer] FFmpeg started:", cli);
-			})
-			.on("error", (err) => {
-				this.ffmpegFinished = true;
-				// Suppress errors that come from our own intentional kill() —
-				// when stop()/leave calls #cleanUp() it sends SIGKILL, which
-				// fluent-ffmpeg turns into an "error" event. Without this guard
-				// that bubbles up as an uncaughtException crashing the process.
-				if (this.stopped) return;
-				const msg = err?.message ?? String(err);
-				if (
-					msg.includes("SIGKILL") ||
-					msg.includes("killed with signal") ||
-					msg.includes("aborted") ||
-					msg.includes("Input stream error")
-				) return;
-				this.emit("error", err);
-			})
-			.on("codecData", (d) => {
-				this.codecData = d;
-			})
-			.on("end", () => {
-				this.ffmpegFinished = true;
-			});
+        fProc
+            .on("start", (cli) => {
+                // Keep the start log — it's the only way to see the exact FFmpeg
+                // command line when diagnosing "Invalid data" errors.
+                console.log("[MediaPlayer] FFmpeg started:", cli);
+            })
+            .on("error", (err) => {
+                this.ffmpegFinished = true;
+                // Suppress errors that come from our own intentional kill() —
+                // when stop()/leave calls #cleanUp() it sends SIGKILL, which
+                // fluent-ffmpeg turns into an "error" event. Without this guard
+                // that bubbles up as an uncaughtException crashing the process.
+                if (this.stopped) return;
+                const msg = err?.message ?? String(err);
+                if (
+                    msg.includes("SIGKILL") ||
+                    msg.includes("killed with signal") ||
+                    msg.includes("aborted") ||
+                    msg.includes("Input stream error")
+                ) return;
+                this.emit("error", err);
+            })
+            .on("codecData", (d) => {
+                this.codecData = d;
+            })
+            .on("end", () => {
+                this.ffmpegFinished = true;
+            });
 
-		this.fProc = fProc;
+        this.fProc = fProc;
 
-		// FIX: store the pipe reference so #cleanUp() can destroy it.
-		const out = fProc.pipe();
-		this._ffmpegOut = out;
+        // FIX: store the pipe reference so #cleanUp() can destroy it.
+        const out = fProc.pipe();
+        this._ffmpegOut = out;
 
-		out.on("data", (chunk) => {
-			if (this.stopped) return;
-			this.chunks.push(chunk);
+        out.on("data", (chunk) => {
+            if (this.stopped) return;
+            this.chunks.push(chunk);
 
-			// BACKPRESSURE: pause FFmpeg output when the buffer is full.
-			// Without this, FFmpeg decodes the entire track into this.chunks
-			// before playback consumes anything.
-			// 100h stream at 48kHz stereo s16le ≈ 64 GB — we cap at ~400 KB.
-			if (this.chunks.length >= MAX_CHUNKS) {
-				try { out.pause(); } catch (_) {}
-			}
+            // BACKPRESSURE: pause FFmpeg output when the buffer is full.
+            // Without this, FFmpeg decodes the entire track into this.chunks
+            // before playback consumes anything.
+            // 100h stream at 48kHz stereo s16le ≈ 64 GB — we cap at ~400 KB.
+            if (this.chunks.length >= MAX_CHUNKS) {
+                try { out.pause(); } catch (_) {}
+            }
 
-			if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
-		});
-		out.on("error", (err) => {
-			this.ffmpegFinished = true;
-			if (!this.stopped) this.emit("error", err);
-		});
-		out.on("end", () => {
-			this.ffmpegFinished = true;
-			if (!this.stopped && this.chunks.length === 0) this.stop();
-		});
-	}
+            if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
+        });
+        out.on("error", (err) => {
+            this.ffmpegFinished = true;
+            if (!this.stopped) this.emit("error", err);
+        });
+        out.on("end", () => {
+            this.ffmpegFinished = true;
+            if (!this.stopped && this.chunks.length === 0) this.stop();
+        });
+    }
 }
 
 module.exports = { MediaPlayer, Media };

--- a/src/Media.js
+++ b/src/Media.js
@@ -4,32 +4,21 @@ const fPath = require("ffmpeg-static");
 const { EventEmitter } = require("events");
 const prism = require("prism-media");
 
-function isIgnorableCaptureError(err) {
-  const msg = err?.message ?? String(err ?? "");
-  return msg.includes("InvalidState") || msg.includes("failed to capture frame") || msg.includes("capture frame");
-}
-
-/**
- * @class
- * @classdesc Basic class to process audio streams. As of 5a2fd7bcde9819c927157a965cfafdb8661f3e4e this doesn't have any functionality anymore and acts more like an interface.
- */
 class Media extends EventEmitter {
-  SAMPLE_RATE = 48000;
-  CHANNELS = 2;
-  id = null;
+	SAMPLE_RATE = 48000;
+	CHANNELS = 2;
+	id = null;
 
-  constructor() {
+	constructor() {
 		super();
-
-    this.id = Math.random().toString(36) + Date.now();
-
-    this.source = new AudioSource(this.SAMPLE_RATE, this.CHANNELS);
-    this.track = LocalAudioTrack.createAudioTrack("audio-" + this.id, this.source);
-  }
+		this.id = Math.random().toString(36) + Date.now();
+		this.source = new AudioSource(this.SAMPLE_RATE, this.CHANNELS);
+		this.track = LocalAudioTrack.createAudioTrack("audio-" + this.id, this.source);
+	}
 
 	playFile(path) {
 		if (!path) throw "You must specify a file to play!";
-		const stream = fs.createReadStream(path);
+		const stream = require("fs").createReadStream(path);
 		this.playStream(stream);
 	}
 	playStream(stream) {
@@ -38,37 +27,21 @@ class Media extends EventEmitter {
 	}
 }
 
-/**
- * @class
- * @augments Media
- * @description An advanced version of the Media class. It also includes media controls like pausing and volume adjustment.
- *
- * @property {number} seconds - The amount of seconds passed during playback.
- * @property {string} currTimestamp - The current timestamp in ffmpeg format `hh:mm:ss`.
- */
 class MediaPlayer extends Media {
-	/**
-	 * @description Initiates the MediaPlayer instance.
-	 * @param {boolean} normalisation=true Wether to pass the `loudnorm` flag to FFmpeg.
-	 *
-	 * @return {MediaPlayer}            The new instance.
-	 */
-  constructor(normalisation=true) {
-    super();
-
-    this.isMediaPlayer = true;
-    this.loudnessNormalisation = normalisation;
-
-    this.initValues();
-  }
+	constructor(normalisation=true) {
+		super();
+		this.isMediaPlayer = true;
+		this.loudnessNormalisation = normalisation;
+		this.initValues();
+	}
 
 	initValues() {
 		this.ready = true;
 		this.volCache = null;
-
 		this.paused = false;
 		this.playing = false;
 		this.started = false;
+		this.stopped = false;
 
 		this.chunks = [];
 		this.ffmpegChunks = [];
@@ -76,117 +49,78 @@ class MediaPlayer extends Media {
 		this.ffmpegFinished = false;
 		this.playedOutSamples = 0;
 		this.codecData = null;
-
 		this.originStream = null;
 		this.fProc = null;
-		this.ffmpegOutput = null;
-		this.stopped = false;
 
 		this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
 		this.volumeTransformer.once("data", () => {
 			this.playing = true;
 			this.emit("startplay");
-		})
+		});
 	}
 
-  pause() {
-    if (this.paused) return;
-    this.paused = true;
-
-    this.emit("pause");
-  }
-  resume() {
-    if (!this.paused) return;
-    this.paused = false;
-
-    if (this.readyPlayPacket) this.playOutPacket();
-    this.emit("unpause");
-  }
-  setVolume(v=1) {
-    return this.volumeTransformer.setVolume(v);
-  }
+	pause() {
+		if (this.paused) return;
+		this.paused = true;
+		this.emit("pause");
+	}
+	resume() {
+		if (!this.paused) return;
+		this.paused = false;
+		if (this.readyPlayPacket) this.playOutPacket();
+		this.emit("unpause");
+	}
+	setVolume(v=1) {
+		this.volCache = v;
+		return this.volumeTransformer.setVolume(v);
+	}
 
 	#cleanUp() {
-		this.stopped = true;
-		this.readyPlayPacket = false;
 		this.originStream?.destroy();
-		this.ffmpegOutput?.destroy?.();
-		if (this.fProc && !this.ffmpegFinished) this.fProc.kill();
-		this.volumeTransformer.destroy();
+		if (this.fProc) {
+			try { this.fProc.kill(); } catch (_) {}
+		}
+		try { this.volumeTransformer.destroy(); } catch (_) {}
 	}
 
 	stop(init=true) {
-		if (this.stopped) return;
-		this.readyPlayPacket = false; // prevent new packets from being played out
-
+		this.stopped = true;
+		this.readyPlayPacket = false;
 		this.#cleanUp();
-
 		if (init) this.initValues();
-
 		this.emit("finish");
 	}
 	destroy() {
 		return this.stop(false);
 	}
 
-	get duration() {
-		return this.codecData?.duration || 0;
+	get duration() { return this.codecData?.duration || 0; }
+	get seconds() { return this.playedOutSamples / this.SAMPLE_RATE; }
+	get localAudioTrack() { return this.track; }
+	get publishOptions() {
+		const options = new TrackPublishOptions();
+		options.source = TrackSource.SOURCE_MICROPHONE;
+		return options;
 	}
-	get currTimestamp() {
-		const sec_num = this.seconds();
-		var hours = Math.floor(sec_num / 3600);
-		var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
-		var seconds = sec_num - (hours * 3600) - (minutes * 60);
-
-		if (hours < 10) { hours = "0" + hours; }
-		if (minutes < 10) { minutes = "0" + minutes; }
-		if (seconds < 10) { seconds = "0" + seconds; }
-		return hours + ':' + minutes + ':' + seconds;
-	}
-	get seconds() {
-		return this.playedOutSamples / this.SAMPLE_RATE;
-	}
-
-  get localAudioTrack() {
-    return this.track;
-  }
-  get publishOptions() {
-    const options = new TrackPublishOptions();
-    options.source = TrackSource.SOURCE_MICROPHONE;
-    return options;
-  }
 	async publishToRoom(room) {
 		await room.localParticipant.publishTrack(this.track, this.publishOptions);
 	}
 
 	async playOutPacket() {
 		return new Promise((res) => {
-			if (this.stopped) return res();
 			if (this.chunks.length === 0) return res(this.readyPlayPacket = true);
 			this.readyPlayPacket = false;
 
 			const c = this.chunks.shift();
 
 			this.volumeTransformer.once("data", async (chunk) => {
-				const samples = new Int16Array(
-					chunk.buffer,
-					chunk.byteOffset,
-					chunk.length / 2 // chunk.length is in bytes
-				);
+				const samples = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.length / 2);
 				const frame = new AudioFrame(
-					samples,
-					this.SAMPLE_RATE,
-					this.CHANNELS,
+					samples, this.SAMPLE_RATE, this.CHANNELS,
 					Math.trunc(samples.length / this.CHANNELS)
-				)
+				);
 
-				try {
-					await this.source.captureFrame(frame);
-				} catch (err) {
-					if (this.stopped || isIgnorableCaptureError(err)) return res();
-					this.emit("error", err);
-					return res();
-				}
+				await this.source.captureFrame(frame);
 				this.playedOutSamples += samples.length / this.CHANNELS;
 
 				if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
@@ -196,50 +130,55 @@ class MediaPlayer extends Media {
 			});
 			this.volumeTransformer.write(c);
 		});
-  }
+	}
 
-  async playStream(stream) {
+	async playStream(stream, options = {}) {
 		this.emit("buffer");
 		this.originStream = stream;
-    this.started = false;
+		this.started = false;
 		this.stopped = false;
-
-    this.ffmpegFinished = false;
+		this.ffmpegFinished = false;
 		this.playedOutSamples = 0;
-    let fProc = ffmpeg(stream)
-      .noVideo()
-      .setFfmpegPath(fPath)
-      //.native() // TODO: check if necessary
-      .outputOptions([
-        `-f s16le`,
-        `-ar ${this.SAMPLE_RATE}`,
-        `-ac ${this.CHANNELS}`
-      ])
-      .on("start", (cli) => {
-        console.log('Ffmpeg process started: ', cli)
-      })
-      .on("error", (err, stdout, stderr) => {
-				this.ffmpegFinished = true;
-        this.emit("error", err);
-      })
-			.on("codecData", (d) => {
-				this.codecData = d;
-			})
-      .on("end", () => {
-        this.ffmpegFinished = true;
-				console.log("ffmpeg finished");
-      });
-		if (this.loudnessNormalisation) {
+
+		// For rawPcm, NodeLink sends s16le 48kHz stereo PCM directly.
+		// We pass it through ffmpeg with -f s16le input format (no re-encoding needed,
+		// just use ffmpeg as a passthrough to get the same backpressure/timing as normal path).
+		const inputOptions = options.rawPcm ? ['-f s16le', '-ar 48000', '-ac 2'] : [];
+
+		let fProc = ffmpeg(stream)
+			.noVideo()
+			.setFfmpegPath(fPath);
+
+		if (inputOptions.length > 0) {
+			fProc = fProc.inputOptions(inputOptions);
+		}
+
+		fProc = fProc.outputOptions([
+			`-f s16le`,
+			`-ar ${this.SAMPLE_RATE}`,
+			`-ac ${this.CHANNELS}`
+		]);
+
+		// Only apply loudnorm on non-rawPcm path (NodeLink PCM is already normalized)
+		const useLoudnorm = options.rawPcm ? false :
+			(options.loudnorm !== undefined ? options.loudnorm : this.loudnessNormalisation);
+		if (useLoudnorm) {
 			fProc = fProc.audioFilters("loudnorm");
 		}
+
+		fProc
+			.on("start", (cli) => { console.log('Ffmpeg process started: ', cli); })
+			.on("error", (err) => { this.ffmpegFinished = true; })
+			.on("codecData", (d) => { this.codecData = d; })
+			.on("end", () => { this.ffmpegFinished = true; });
+
 		this.fProc = fProc;
-    const out = fProc.pipe();
-		this.ffmpegOutput = out;
-    out.on("data", (chunk) => {
+		const out = fProc.pipe();
+		out.on("data", (chunk) => {
 			if (this.stopped) return;
-      this.chunks.push(chunk)
-      if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
-    });
+			this.chunks.push(chunk);
+			if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
+		});
 		out.on("error", (err) => {
 			this.ffmpegFinished = true;
 			if (!this.stopped) this.emit("error", err);
@@ -248,7 +187,7 @@ class MediaPlayer extends Media {
 			this.ffmpegFinished = true;
 			if (!this.stopped && this.chunks.length === 0) this.stop();
 		});
-  }
+	}
 }
 
 module.exports = { MediaPlayer, Media }

--- a/src/Media.js
+++ b/src/Media.js
@@ -37,27 +37,19 @@ class Media extends EventEmitter {
  * @augments Media
  * @description An advanced version of the Media class with media controls.
  *
- * How the pipeline works (no chunk array, no manual backpressure):
+ * Pipeline (demand-driven, nothing buffered in JS memory):
  *
- *   HTTP/file stream
- *       → FFmpeg (decode/resample to s16le 48kHz stereo)
- *           → VolumeTransformer (prism-media Transform stream)
- *               → _processLoop() reads one frame at a time via async iterator
- *                   → AudioSource.captureFrame() (real-time, blocks until LiveKit
- *                      is ready for the next frame)
+ *   FFmpeg stdout (paused/Readable mode)
+ *       → one chunk read manually via stream.read()
+ *           → VolumeTransformer.write() / read one transformed chunk
+ *               → AudioFrame → AudioSource.captureFrame()  (real-time async)
+ *                   → loop back and read the next chunk
  *
- * Because captureFrame() is async and real-time, the entire pipeline naturally
- * throttles: VolumeTransformer's internal buffer fills → FFmpeg stdout buffer
- * fills → OS pipe buffer fills → FFmpeg itself slows to real-time speed.
- * No data is stored in JS memory regardless of track length.
- *
- * @property {number} seconds  - Seconds elapsed during playback.
- * @property {string} currTimestamp - Current timestamp as hh:mm:ss.
+ * FFmpeg stdout is kept in paused mode. We call .read() only after
+ * captureFrame() resolves, so FFmpeg is throttled to exactly playback speed
+ * and nothing accumulates in memory regardless of track length.
  */
 class MediaPlayer extends Media {
-    /**
-     * @param {boolean} normalisation=true Whether to pass the loudnorm filter to FFmpeg.
-     */
     constructor(normalisation = true) {
         super();
         this.isMediaPlayer = true;
@@ -76,14 +68,9 @@ class MediaPlayer extends Media {
         this.originStream     = null;
         this.fProc            = null;
         this._ffmpegOut       = null;
-        // Resolve handle so _processLoop can be unblocked on pause/stop.
         this._unpauseResolve  = null;
 
         this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
-        this.volumeTransformer.once("data", () => {
-            this.playing = true;
-            this.emit("startplay");
-        });
     }
 
     pause() {
@@ -95,7 +82,6 @@ class MediaPlayer extends Media {
     resume() {
         if (!this.paused) return;
         this.paused = false;
-        // Unblock the _processLoop which is waiting on the pause gate.
         if (this._unpauseResolve) {
             this._unpauseResolve();
             this._unpauseResolve = null;
@@ -108,22 +94,18 @@ class MediaPlayer extends Media {
         return this.volumeTransformer.setVolume(v);
     }
 
-    // Wait until unpaused (or stopped). Called inside the frame loop.
     _waitForResume() {
-        return new Promise(resolve => {
-            this._unpauseResolve = resolve;
-        });
+        return new Promise(resolve => { this._unpauseResolve = resolve; });
     }
 
     #cleanUp() {
-        try { this._ffmpegOut?.destroy(); }    catch (_) {}
+        try { this._ffmpegOut?.destroy(); }       catch (_) {}
         this._ffmpegOut = null;
-        try { this.originStream?.destroy(); }  catch (_) {}
+        try { this.originStream?.destroy(); }     catch (_) {}
         if (this.fProc) {
-            try { this.fProc.kill(); }         catch (_) {}
+            try { this.fProc.kill(); }            catch (_) {}
         }
         try { this.volumeTransformer.destroy(); } catch (_) {}
-        // Unblock _processLoop if paused so it can see stopped=true and exit.
         if (this._unpauseResolve) {
             this._unpauseResolve();
             this._unpauseResolve = null;
@@ -131,43 +113,28 @@ class MediaPlayer extends Media {
     }
 
     stop(init = true) {
-        // Only emit "finish" if we were actually playing. This prevents the
-        // redundant stop() call at the top of _doPlayNext (for cleanup between
-        // songs) from firing "finish" on a player that already naturally stopped,
-        // which would resolve _streamViaRevoice\'s once("finish") for the next
-        // song before it starts — causing every queued song to be skipped.
         const wasPlaying = !this.stopped;
-
         this.stopped = true;
         this.#cleanUp();
-
         if (init) {
             this.initValues();
-            // initValues() resets stopped→false. Re-apply so redundant stop()
-            // calls stay silent until playStream() marks the player live again.
-            this.stopped = true;
+            this.stopped = true; // survive initValues() reset
         }
-
         if (wasPlaying) this.emit("finish");
     }
 
-    destroy() {
-        return this.stop(false);
-    }
+    destroy() { return this.stop(false); }
 
-    get duration()      { return this.codecData?.duration || 0; }
-    get seconds()       { return this.playedOutSamples / this.SAMPLE_RATE; }
+    get duration()        { return this.codecData?.duration || 0; }
+    get seconds()         { return this.playedOutSamples / this.SAMPLE_RATE; }
     get localAudioTrack() { return this.track; }
 
     get currTimestamp() {
-        const sec_num = this.seconds;
-        let hours   = Math.floor(sec_num / 3600);
-        let minutes = Math.floor((sec_num - hours * 3600) / 60);
-        let seconds = Math.floor(sec_num - hours * 3600 - minutes * 60);
-        if (hours   < 10) hours   = "0" + hours;
-        if (minutes < 10) minutes = "0" + minutes;
-        if (seconds < 10) seconds = "0" + seconds;
-        return `${hours}:${minutes}:${seconds}`;
+        const s   = Math.floor(this.seconds);
+        const h   = Math.floor(s / 3600);
+        const m   = Math.floor((s % 3600) / 60);
+        const sec = s % 60;
+        return [h, m, sec].map(n => String(n).padStart(2, "0")).join(":");
     }
 
     get publishOptions() {
@@ -181,61 +148,106 @@ class MediaPlayer extends Media {
     }
 
     /**
-     * Core frame loop. Reads PCM chunks from the VolumeTransformer async
-     * iterator one at a time, converts each to an AudioFrame, and feeds it
-     * to LiveKit. Because captureFrame() is real-time async, this naturally
-     * throttles FFmpeg to playback speed — no buffering in JS memory at all.
+     * Read exactly one chunk from a stream that is in paused mode.
+     * Returns null when the stream ends.
      */
-    async _processLoop(volumeTransformer) {
-        try {
-            for await (const chunk of volumeTransformer) {
-                if (this.stopped) break;
+    _readChunk(readable) {
+        return new Promise((resolve) => {
+            // Try a synchronous read first — data may already be in the
+            // stream's tiny internal highWaterMark buffer (default 16 KB).
+            const chunk = readable.read();
+            if (chunk !== null) return resolve(chunk);
 
-                // Pause gate — wait here until resume() is called.
-                while (this.paused && !this.stopped) {
-                    await this._waitForResume();
-                }
-                if (this.stopped) break;
+            // Nothing available yet — wait for the next "readable" event,
+            // which fires when at least one chunk is ready, then read it.
+            const onReadable = () => {
+                cleanup();
+                resolve(readable.read());
+            };
+            const onEnd = () => { cleanup(); resolve(null); };
+            const onClose = () => { cleanup(); resolve(null); };
+            const onError = () => { cleanup(); resolve(null); };
 
-                const samples = new Int16Array(
-                    chunk.buffer,
-                    chunk.byteOffset,
-                    chunk.length / 2
-                );
-                const frame = new AudioFrame(
-                    samples,
-                    this.SAMPLE_RATE,
-                    this.CHANNELS,
-                    Math.trunc(samples.length / this.CHANNELS)
-                );
+            const cleanup = () => {
+                readable.off("readable", onReadable);
+                readable.off("end",      onEnd);
+                readable.off("close",    onClose);
+                readable.off("error",    onError);
+            };
 
-                await this.source.captureFrame(frame);
-                if (this.stopped) break;
+            readable.once("readable", onReadable);
+            readable.once("end",      onEnd);
+            readable.once("close",    onClose);
+            readable.once("error",    onError);
+        });
+    }
 
-                this.playedOutSamples += samples.length / this.CHANNELS;
+    /**
+     * Write one chunk into the VolumeTransformer and read back the
+     * transformed output synchronously. prism-media's VolumeTransformer
+     * is a synchronous Transform — one write always produces one read.
+     */
+    _transformChunk(chunk) {
+        this.volumeTransformer.write(chunk);
+        return this.volumeTransformer.read();
+    }
+
+    /**
+     * Demand-driven playback loop.
+     *
+     * We keep FFmpeg's output stream in paused (non-flowing) mode and call
+     * .read() only after captureFrame() has returned. This means:
+     *   - FFmpeg stdout OS buffer: at most ~64 KB (kernel default pipe size)
+     *   - VolumeTransformer buffer: at most one chunk (~few KB, highWaterMark)
+     *   - JS heap: nothing stored between iterations
+     *
+     * Total memory per player: ~few KB, regardless of track length.
+     */
+    async _processLoop(out) {
+        // Ensure the stream is in paused mode — we drive reads manually.
+        out.pause();
+
+        let firstChunk = true;
+        while (!this.stopped) {
+            // Pause gate — block here without consuming any data.
+            while (this.paused && !this.stopped) {
+                await this._waitForResume();
             }
-        } catch (err) {
-            // Destroyed/ended streams throw ERR_STREAM_DESTROYED — that\'s
-            // expected on stop(). Only surface genuine unexpected errors.
-            if (!this.stopped) {
-                const msg = err?.message ?? String(err);
-                const graceful =
-                    msg.includes("ERR_STREAM_DESTROYED") ||
-                    msg.includes("aborted") ||
-                    msg.includes("premature close");
-                if (!graceful) this.emit("error", err);
+            if (this.stopped) break;
+
+            const raw = await this._readChunk(out);
+            if (raw === null || this.stopped) break; // stream ended or stopped
+
+            const chunk = this._transformChunk(raw);
+            if (!chunk) continue; // transformer not ready yet (shouldn't happen)
+
+            if (firstChunk) {
+                firstChunk = false;
+                this.playing = true;
+                this.emit("startplay");
             }
+
+            const samples = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.length / 2);
+            const frame   = new AudioFrame(
+                samples, this.SAMPLE_RATE, this.CHANNELS,
+                Math.trunc(samples.length / this.CHANNELS)
+            );
+
+            // captureFrame is real-time async — it resolves at exactly the
+            // right wall-clock time for the frame. This is what throttles the
+            // entire pipeline: FFmpeg can't produce more data than we consume.
+            await this.source.captureFrame(frame);
+            if (this.stopped) break;
+
+            this.playedOutSamples += samples.length / this.CHANNELS;
         }
 
-        // Loop exited — either track ended naturally or stop() was called.
         if (!this.stopped) this.stop();
     }
 
     async playStream(stream, options = {}) {
         this.emit("buffer");
-        this.originStream = stream;
-        // Mark as live. stop() keeps stopped=true after cleanup so redundant
-        // stop() calls are silent; playStream() is what reactivates the player.
+        this.originStream     = stream;
         this.stopped          = false;
         this.playing          = false;
         this.playedOutSamples = 0;
@@ -263,34 +275,31 @@ class MediaPlayer extends Media {
         if (useLoudnorm) fProc = fProc.audioFilters("loudnorm");
 
         fProc
-            .on("start", (cli) => console.log("[MediaPlayer] FFmpeg started:", cli))
-            .on("error", (err) => {
-                // Suppress intentional kills (stop/leave sends SIGKILL).
+            .on("start",    (cli) => console.log("[MediaPlayer] FFmpeg started:", cli))
+            .on("error",    (err) => {
                 if (this.stopped) return;
                 const msg = err?.message ?? String(err);
                 if (
-                    msg.includes("SIGKILL") ||
+                    msg.includes("SIGKILL")            ||
                     msg.includes("killed with signal") ||
-                    msg.includes("aborted") ||
+                    msg.includes("aborted")            ||
                     msg.includes("Input stream error")
                 ) return;
                 this.emit("error", err);
             })
             .on("codecData", (d) => { this.codecData = d; })
-            .on("end",       ()  => { /* _processLoop handles completion */ });
+            .on("end",       ()  => { /* _processLoop drives completion */ });
 
         this.fProc = fProc;
 
-        // Pipe FFmpeg output directly into the VolumeTransformer.
-        // Node.js stream piping handles backpressure: when captureFrame()
-        // blocks, the Transform buffer fills, FFmpeg stdout buffer fills,
-        // and FFmpeg itself throttles — no data accumulates in JS memory.
+        // Get the output stream and immediately switch it to paused mode
+        // so _processLoop controls every read.
         const out = fProc.pipe();
         this._ffmpegOut = out;
-        out.pipe(this.volumeTransformer);
 
-        // Start the async frame loop. Runs concurrently with the pipe.
-        this._processLoop(this.volumeTransformer);
+        // Drive playback. _processLoop keeps out in paused mode and only
+        // calls .read() after each captureFrame() — true demand-driven I/O.
+        this._processLoop(out);
     }
 }
 

--- a/src/Media.js
+++ b/src/Media.js
@@ -2,8 +2,13 @@ const { AudioSource, LocalAudioTrack, TrackPublishOptions, TrackSource, AudioFra
 const ffmpeg = require("fluent-ffmpeg");
 const fPath = require("ffmpeg-static");
 const { EventEmitter } = require("events");
+const fs = require("fs"); // FIX: was missing — playFile() would crash with ReferenceError
 const prism = require("prism-media");
 
+/**
+ * @class
+ * @classdesc Basic class to process audio streams.
+ */
 class Media extends EventEmitter {
 	SAMPLE_RATE = 48000;
 	CHANNELS = 2;
@@ -18,7 +23,7 @@ class Media extends EventEmitter {
 
 	playFile(path) {
 		if (!path) throw "You must specify a file to play!";
-		const stream = require("fs").createReadStream(path);
+		const stream = fs.createReadStream(path);
 		this.playStream(stream);
 	}
 	playStream(stream) {
@@ -27,8 +32,19 @@ class Media extends EventEmitter {
 	}
 }
 
+/**
+ * @class
+ * @augments Media
+ * @description An advanced version of the Media class with media controls.
+ *
+ * @property {number} seconds - Seconds elapsed during playback.
+ * @property {string} currTimestamp - Current timestamp as `hh:mm:ss`.
+ */
 class MediaPlayer extends Media {
-	constructor(normalisation=true) {
+	/**
+	 * @param {boolean} normalisation=true Whether to pass the `loudnorm` filter to FFmpeg.
+	 */
+	constructor(normalisation = true) {
 		super();
 		this.isMediaPlayer = true;
 		this.loudnessNormalisation = normalisation;
@@ -38,19 +54,26 @@ class MediaPlayer extends Media {
 	initValues() {
 		this.ready = true;
 		this.volCache = null;
+
 		this.paused = false;
 		this.playing = false;
 		this.started = false;
+		// FIX: track stopped state so dangling volumeTransformer callbacks
+		// that fire after stop() don't try to capture frames on a dead player.
 		this.stopped = false;
 
 		this.chunks = [];
-		this.ffmpegChunks = [];
 		this.readyPlayPacket = true;
 		this.ffmpegFinished = false;
 		this.playedOutSamples = 0;
 		this.codecData = null;
+
 		this.originStream = null;
 		this.fProc = null;
+		// FIX: store the ffmpeg output pipe so #cleanUp() can destroy it and
+		// free its internal buffer. In the original code this was a local
+		// variable inside playStream() and was unreachable from cleanup.
+		this._ffmpegOut = null;
 
 		this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
 		this.volumeTransformer.once("data", () => {
@@ -64,44 +87,86 @@ class MediaPlayer extends Media {
 		this.paused = true;
 		this.emit("pause");
 	}
+
 	resume() {
 		if (!this.paused) return;
 		this.paused = false;
 		if (this.readyPlayPacket) this.playOutPacket();
 		this.emit("unpause");
 	}
-	setVolume(v=1) {
+
+	setVolume(v = 1) {
 		this.volCache = v;
 		return this.volumeTransformer.setVolume(v);
 	}
 
 	#cleanUp() {
-		this.originStream?.destroy();
+		// FIX: destroy the ffmpeg output stream first — this frees Node.js
+		// Readable buffer memory that was holding decoded PCM chunks.
+		try { this._ffmpegOut?.destroy(); } catch (_) {}
+		this._ffmpegOut = null;
+
+		// Destroy the origin (input) stream so the HTTP connection closes.
+		try { this.originStream?.destroy(); } catch (_) {}
+
+		// FIX: original logic was `if (this.ffmpegFinished) this.fProc.kill()`
+		// which is backwards — it only killed ffmpeg when already done (a no-op)
+		// and left a live ffmpeg process running when stop() was called mid-stream.
+		// Correct: always kill if the process is still alive.
 		if (this.fProc) {
 			try { this.fProc.kill(); } catch (_) {}
 		}
+
+		// Clear the chunks array so the PCM buffer is GC-eligible immediately.
+		this.chunks = [];
+
 		try { this.volumeTransformer.destroy(); } catch (_) {}
 	}
 
-	stop(init=true) {
+	stop(init = true) {
 		this.stopped = true;
-		this.readyPlayPacket = false;
+		this.readyPlayPacket = false; // prevent new packets from being queued
 		this.#cleanUp();
 		if (init) this.initValues();
 		this.emit("finish");
 	}
+
 	destroy() {
 		return this.stop(false);
 	}
 
-	get duration() { return this.codecData?.duration || 0; }
-	get seconds() { return this.playedOutSamples / this.SAMPLE_RATE; }
-	get localAudioTrack() { return this.track; }
+	get duration() {
+		return this.codecData?.duration || 0;
+	}
+
+	get currTimestamp() {
+		// FIX: original called `this.seconds()` as a function but `seconds`
+		// is a getter — calling it as a function returned the getter function
+		// itself, making Math.floor(NaN) produce "NaN:NaN:NaN".
+		const sec_num = this.seconds;
+		var hours   = Math.floor(sec_num / 3600);
+		var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
+		var seconds = sec_num - (hours * 3600) - (minutes * 60);
+		if (hours   < 10) { hours   = "0" + hours;   }
+		if (minutes < 10) { minutes = "0" + minutes; }
+		if (seconds < 10) { seconds = "0" + seconds; }
+		return hours + ":" + minutes + ":" + seconds;
+	}
+
+	get seconds() {
+		return this.playedOutSamples / this.SAMPLE_RATE;
+	}
+
+	get localAudioTrack() {
+		return this.track;
+	}
+
 	get publishOptions() {
 		const options = new TrackPublishOptions();
 		options.source = TrackSource.SOURCE_MICROPHONE;
 		return options;
 	}
+
 	async publishToRoom(room) {
 		await room.localParticipant.publishTrack(this.track, this.publishOptions);
 	}
@@ -114,9 +179,21 @@ class MediaPlayer extends Media {
 			const c = this.chunks.shift();
 
 			this.volumeTransformer.once("data", async (chunk) => {
-				const samples = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.length / 2);
+				// FIX: guard against dangling promises. stop() destroys the
+				// volumeTransformer but a .once("data") listener added just
+				// before stop() fires can still execute here with stale data,
+				// creating an AudioFrame for a player that's already dead.
+				if (this.stopped) return res();
+
+				const samples = new Int16Array(
+					chunk.buffer,
+					chunk.byteOffset,
+					chunk.length / 2 // chunk.length is in bytes
+				);
 				const frame = new AudioFrame(
-					samples, this.SAMPLE_RATE, this.CHANNELS,
+					samples,
+					this.SAMPLE_RATE,
+					this.CHANNELS,
 					Math.trunc(samples.length / this.CHANNELS)
 				);
 
@@ -132,6 +209,8 @@ class MediaPlayer extends Media {
 		});
 	}
 
+	// FIX: accept the same `options` parameter that Player.mjs passes so it
+	// doesn't silently discard rawPcm / loudnorm overrides.
 	async playStream(stream, options = {}) {
 		this.emit("buffer");
 		this.originStream = stream;
@@ -140,17 +219,21 @@ class MediaPlayer extends Media {
 		this.ffmpegFinished = false;
 		this.playedOutSamples = 0;
 
-		// For rawPcm, NodeLink sends s16le 48kHz stereo PCM directly.
-		// We pass it through ffmpeg with -f s16le input format (no re-encoding needed,
-		// just use ffmpeg as a passthrough to get the same backpressure/timing as normal path).
-		const inputOptions = options.rawPcm ? ['-f s16le', '-ar 48000', '-ac 2'] : [];
+		// When the caller signals rawPcm=true the stream is already decoded
+		// s16le PCM (e.g. NodeLink /v4/loadstream). Tell FFmpeg the format
+		// explicitly so it doesn't try to demux it as a container.
+		const isRawPcm = options.rawPcm === true;
 
 		let fProc = ffmpeg(stream)
 			.noVideo()
 			.setFfmpegPath(fPath);
 
-		if (inputOptions.length > 0) {
-			fProc = fProc.inputOptions(inputOptions);
+		if (isRawPcm) {
+			fProc = fProc.inputOptions([
+				"-f s16le",
+				`-ar ${this.SAMPLE_RATE}`,
+				`-ac ${this.CHANNELS}`
+			]);
 		}
 
 		fProc = fProc.outputOptions([
@@ -159,21 +242,37 @@ class MediaPlayer extends Media {
 			`-ac ${this.CHANNELS}`
 		]);
 
-		// Only apply loudnorm on non-rawPcm path (NodeLink PCM is already normalized)
-		const useLoudnorm = options.rawPcm ? false :
-			(options.loudnorm !== undefined ? options.loudnorm : this.loudnessNormalisation);
+		// Apply loudnorm unless explicitly disabled or the input is already raw PCM.
+		const useLoudnorm = isRawPcm ? false
+			: (options.loudnorm !== undefined ? options.loudnorm : this.loudnessNormalisation);
 		if (useLoudnorm) {
 			fProc = fProc.audioFilters("loudnorm");
 		}
 
 		fProc
-			.on("start", (cli) => { console.log('Ffmpeg process started: ', cli); })
-			.on("error", (err) => { this.ffmpegFinished = true; })
-			.on("codecData", (d) => { this.codecData = d; })
-			.on("end", () => { this.ffmpegFinished = true; });
+			.on("start", (cli) => {
+				// Keep the start log — it's the only way to see the exact FFmpeg
+				// command line when diagnosing "Invalid data" errors.
+				console.log("[MediaPlayer] FFmpeg started:", cli);
+			})
+			.on("error", (err) => {
+				this.ffmpegFinished = true;
+				// Propagate the error so Player.mjs can handle it.
+				if (!this.stopped) this.emit("error", err);
+			})
+			.on("codecData", (d) => {
+				this.codecData = d;
+			})
+			.on("end", () => {
+				this.ffmpegFinished = true;
+			});
 
 		this.fProc = fProc;
+
+		// FIX: store the pipe reference so #cleanUp() can destroy it.
 		const out = fProc.pipe();
+		this._ffmpegOut = out;
+
 		out.on("data", (chunk) => {
 			if (this.stopped) return;
 			this.chunks.push(chunk);
@@ -190,4 +289,4 @@ class MediaPlayer extends Media {
 	}
 }
 
-module.exports = { MediaPlayer, Media }
+module.exports = { MediaPlayer, Media };

--- a/src/Media.js
+++ b/src/Media.js
@@ -2,20 +2,8 @@ const { AudioSource, LocalAudioTrack, TrackPublishOptions, TrackSource, AudioFra
 const ffmpeg = require("fluent-ffmpeg");
 const fPath = require("ffmpeg-static");
 const { EventEmitter } = require("events");
-const fs = require("fs"); // FIX: was missing — playFile() would crash with ReferenceError
+const fs = require("fs");
 const prism = require("prism-media");
-
-// ---------------------------------------------------------------------------
-// Backpressure constants
-//
-// FFmpeg decodes audio far faster than real-time. Without a cap every player
-// buffers the entire decoded track — a 100h stream is ~64 GB of s16le PCM.
-//
-// At ~4 KB per chunk, MAX_CHUNKS=100 keeps the buffer under ~400 KB (~2 s of
-// audio) per player regardless of track length.
-// ---------------------------------------------------------------------------
-const MAX_CHUNKS    = 100; // pause FFmpeg output when buffer reaches this size
-const RESUME_CHUNKS =  40; // resume FFmpeg output once buffer drains this low
 
 /**
  * @class
@@ -49,12 +37,26 @@ class Media extends EventEmitter {
  * @augments Media
  * @description An advanced version of the Media class with media controls.
  *
- * @property {number} seconds - Seconds elapsed during playback.
- * @property {string} currTimestamp - Current timestamp as `hh:mm:ss`.
+ * How the pipeline works (no chunk array, no manual backpressure):
+ *
+ *   HTTP/file stream
+ *       → FFmpeg (decode/resample to s16le 48kHz stereo)
+ *           → VolumeTransformer (prism-media Transform stream)
+ *               → _processLoop() reads one frame at a time via async iterator
+ *                   → AudioSource.captureFrame() (real-time, blocks until LiveKit
+ *                      is ready for the next frame)
+ *
+ * Because captureFrame() is async and real-time, the entire pipeline naturally
+ * throttles: VolumeTransformer's internal buffer fills → FFmpeg stdout buffer
+ * fills → OS pipe buffer fills → FFmpeg itself slows to real-time speed.
+ * No data is stored in JS memory regardless of track length.
+ *
+ * @property {number} seconds  - Seconds elapsed during playback.
+ * @property {string} currTimestamp - Current timestamp as hh:mm:ss.
  */
 class MediaPlayer extends Media {
     /**
-     * @param {boolean} normalisation=true Whether to pass the `loudnorm` filter to FFmpeg.
+     * @param {boolean} normalisation=true Whether to pass the loudnorm filter to FFmpeg.
      */
     constructor(normalisation = true) {
         super();
@@ -64,28 +66,18 @@ class MediaPlayer extends Media {
     }
 
     initValues() {
-        this.ready = true;
-        this.volCache = null;
-
-        this.paused = false;
-        this.playing = false;
-        this.started = false;
-        // FIX: track stopped state so dangling volumeTransformer callbacks
-        // that fire after stop() don't try to capture frames on a dead player.
-        this.stopped = false;
-
-        this.chunks = [];
-        this.readyPlayPacket = true;
-        this.ffmpegFinished = false;
+        this.ready            = true;
+        this.volCache         = null;
+        this.paused           = false;
+        this.playing          = false;
+        this.stopped          = false;
         this.playedOutSamples = 0;
-        this.codecData = null;
-
-        this.originStream = null;
-        this.fProc = null;
-        // FIX: store the ffmpeg output pipe so #cleanUp() can destroy it and
-        // free its internal buffer. In the original code this was a local
-        // variable inside playStream() and was unreachable from cleanup.
-        this._ffmpegOut = null;
+        this.codecData        = null;
+        this.originStream     = null;
+        this.fProc            = null;
+        this._ffmpegOut       = null;
+        // Resolve handle so _processLoop can be unblocked on pause/stop.
+        this._unpauseResolve  = null;
 
         this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
         this.volumeTransformer.once("data", () => {
@@ -97,20 +89,17 @@ class MediaPlayer extends Media {
     pause() {
         if (this.paused) return;
         this.paused = true;
-        // Also pause the FFmpeg output so we stop accumulating chunks while
-        // playback is suspended — without this the buffer keeps growing.
-        try { this._ffmpegOut?.pause(); } catch (_) {}
         this.emit("pause");
     }
 
     resume() {
         if (!this.paused) return;
         this.paused = false;
-        // Only resume FFmpeg output if the buffer has room.
-        if (this.chunks.length < RESUME_CHUNKS) {
-            try { this._ffmpegOut?.resume(); } catch (_) {}
+        // Unblock the _processLoop which is waiting on the pause gate.
+        if (this._unpauseResolve) {
+            this._unpauseResolve();
+            this._unpauseResolve = null;
         }
-        if (this.readyPlayPacket) this.playOutPacket();
         this.emit("unpause");
     }
 
@@ -119,51 +108,46 @@ class MediaPlayer extends Media {
         return this.volumeTransformer.setVolume(v);
     }
 
+    // Wait until unpaused (or stopped). Called inside the frame loop.
+    _waitForResume() {
+        return new Promise(resolve => {
+            this._unpauseResolve = resolve;
+        });
+    }
+
     #cleanUp() {
-        // FIX: destroy the ffmpeg output stream first — this frees Node.js
-        // Readable buffer memory that was holding decoded PCM chunks.
-        try { this._ffmpegOut?.destroy(); } catch (_) {}
+        try { this._ffmpegOut?.destroy(); }    catch (_) {}
         this._ffmpegOut = null;
-
-        // Destroy the origin (input) stream so the HTTP connection closes.
-        try { this.originStream?.destroy(); } catch (_) {}
-
-        // FIX: original logic was `if (this.ffmpegFinished) this.fProc.kill()`
-        // which is backwards — it only killed ffmpeg when already done (a no-op)
-        // and left a live ffmpeg process running when stop() was called mid-stream.
-        // Correct: always kill if the process is still alive.
+        try { this.originStream?.destroy(); }  catch (_) {}
         if (this.fProc) {
-            try { this.fProc.kill(); } catch (_) {}
+            try { this.fProc.kill(); }         catch (_) {}
         }
-
-        // Clear the chunks array so the PCM buffer is GC-eligible immediately.
-        this.chunks = [];
-
         try { this.volumeTransformer.destroy(); } catch (_) {}
+        // Unblock _processLoop if paused so it can see stopped=true and exit.
+        if (this._unpauseResolve) {
+            this._unpauseResolve();
+            this._unpauseResolve = null;
+        }
     }
 
     stop(init = true) {
-        // Only emit "finish" if we were actually in a playing state.
-        // _doPlayNext calls stop() at the top of every song transition to ensure
-        // cleanup — but if the song already ended naturally, stop() was already
-        // called internally, and a second "finish" would resolve _streamViaRevoice's
-        // once("finish") listener for the *next* song before it starts, causing
-        // every song after the first to be immediately skipped.
+        // Only emit "finish" if we were actually playing. This prevents the
+        // redundant stop() call at the top of _doPlayNext (for cleanup between
+        // songs) from firing "finish" on a player that already naturally stopped,
+        // which would resolve _streamViaRevoice\'s once("finish") for the next
+        // song before it starts — causing every queued song to be skipped.
         const wasPlaying = !this.stopped;
 
         this.stopped = true;
-        this.readyPlayPacket = false;
         this.#cleanUp();
 
         if (init) {
             this.initValues();
-            // initValues() resets stopped→false (player is ready for reuse).
-            // Keep stopped=true until playStream() is called so any redundant
-            // stop() calls between song transitions don't re-emit "finish".
+            // initValues() resets stopped→false. Re-apply so redundant stop()
+            // calls stay silent until playStream() marks the player live again.
             this.stopped = true;
         }
 
-        // Only fire "finish" once per actual playback session.
         if (wasPlaying) this.emit("finish");
     }
 
@@ -171,30 +155,19 @@ class MediaPlayer extends Media {
         return this.stop(false);
     }
 
-    get duration() {
-        return this.codecData?.duration || 0;
-    }
+    get duration()      { return this.codecData?.duration || 0; }
+    get seconds()       { return this.playedOutSamples / this.SAMPLE_RATE; }
+    get localAudioTrack() { return this.track; }
 
     get currTimestamp() {
-        // FIX: original called `this.seconds()` as a function but `seconds`
-        // is a getter — calling it as a function returned the getter function
-        // itself, making Math.floor(NaN) produce "NaN:NaN:NaN".
         const sec_num = this.seconds;
-        var hours   = Math.floor(sec_num / 3600);
-        var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
-        var seconds = sec_num - (hours * 3600) - (minutes * 60);
-        if (hours   < 10) { hours   = "0" + hours;   }
-        if (minutes < 10) { minutes = "0" + minutes; }
-        if (seconds < 10) { seconds = "0" + seconds; }
-        return hours + ":" + minutes + ":" + seconds;
-    }
-
-    get seconds() {
-        return this.playedOutSamples / this.SAMPLE_RATE;
-    }
-
-    get localAudioTrack() {
-        return this.track;
+        let hours   = Math.floor(sec_num / 3600);
+        let minutes = Math.floor((sec_num - hours * 3600) / 60);
+        let seconds = Math.floor(sec_num - hours * 3600 - minutes * 60);
+        if (hours   < 10) hours   = "0" + hours;
+        if (minutes < 10) minutes = "0" + minutes;
+        if (seconds < 10) seconds = "0" + seconds;
+        return `${hours}:${minutes}:${seconds}`;
     }
 
     get publishOptions() {
@@ -207,24 +180,27 @@ class MediaPlayer extends Media {
         await room.localParticipant.publishTrack(this.track, this.publishOptions);
     }
 
-    async playOutPacket() {
-        return new Promise((res) => {
-            if (this.chunks.length === 0) return res(this.readyPlayPacket = true);
-            this.readyPlayPacket = false;
+    /**
+     * Core frame loop. Reads PCM chunks from the VolumeTransformer async
+     * iterator one at a time, converts each to an AudioFrame, and feeds it
+     * to LiveKit. Because captureFrame() is real-time async, this naturally
+     * throttles FFmpeg to playback speed — no buffering in JS memory at all.
+     */
+    async _processLoop(volumeTransformer) {
+        try {
+            for await (const chunk of volumeTransformer) {
+                if (this.stopped) break;
 
-            const c = this.chunks.shift();
-
-            this.volumeTransformer.once("data", async (chunk) => {
-                // FIX: guard against dangling promises. stop() destroys the
-                // volumeTransformer but a .once("data") listener added just
-                // before stop() fires can still execute here with stale data,
-                // creating an AudioFrame for a player that's already dead.
-                if (this.stopped) return res();
+                // Pause gate — wait here until resume() is called.
+                while (this.paused && !this.stopped) {
+                    await this._waitForResume();
+                }
+                if (this.stopped) break;
 
                 const samples = new Int16Array(
                     chunk.buffer,
                     chunk.byteOffset,
-                    chunk.length / 2 // chunk.length is in bytes
+                    chunk.length / 2
                 );
                 const frame = new AudioFrame(
                     samples,
@@ -234,49 +210,39 @@ class MediaPlayer extends Media {
                 );
 
                 await this.source.captureFrame(frame);
+                if (this.stopped) break;
+
                 this.playedOutSamples += samples.length / this.CHANNELS;
+            }
+        } catch (err) {
+            // Destroyed/ended streams throw ERR_STREAM_DESTROYED — that\'s
+            // expected on stop(). Only surface genuine unexpected errors.
+            if (!this.stopped) {
+                const msg = err?.message ?? String(err);
+                const graceful =
+                    msg.includes("ERR_STREAM_DESTROYED") ||
+                    msg.includes("aborted") ||
+                    msg.includes("premature close");
+                if (!graceful) this.emit("error", err);
+            }
+        }
 
-                // BACKPRESSURE: resume FFmpeg output when the buffer drains
-                // below the low-water mark so it can refill the ~400 KB window.
-                if (
-                    this._ffmpegOut &&
-                    !this.paused &&
-                    !this.ffmpegFinished &&
-                    this.chunks.length < RESUME_CHUNKS
-                ) {
-                    try { this._ffmpegOut.resume(); } catch (_) {}
-                }
-
-                if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
-                this.readyPlayPacket = true;
-                if (this.chunks.length === 0 && this.ffmpegFinished) this.stop();
-                return res();
-            });
-            this.volumeTransformer.write(c);
-        });
+        // Loop exited — either track ended naturally or stop() was called.
+        if (!this.stopped) this.stop();
     }
 
-    // FIX: accept the same `options` parameter that Player.mjs passes so it
-    // doesn't silently discard rawPcm / loudnorm overrides.
     async playStream(stream, options = {}) {
         this.emit("buffer");
         this.originStream = stream;
-        this.started = false;
-        // Mark as live — stop() sets stopped=true after initValues() so that
-        // redundant stop() calls between song transitions don't re-emit "finish".
-        // playStream() is the authoritative signal that playback has started.
-        this.stopped = false;
-        this.ffmpegFinished = false;
+        // Mark as live. stop() keeps stopped=true after cleanup so redundant
+        // stop() calls are silent; playStream() is what reactivates the player.
+        this.stopped          = false;
+        this.playing          = false;
         this.playedOutSamples = 0;
 
-        // When the caller signals rawPcm=true the stream is already decoded
-        // s16le PCM (e.g. NodeLink /v4/loadstream). Tell FFmpeg the format
-        // explicitly so it doesn't try to demux it as a container.
         const isRawPcm = options.rawPcm === true;
 
-        let fProc = ffmpeg(stream)
-            .noVideo()
-            .setFfmpegPath(fPath);
+        let fProc = ffmpeg(stream).noVideo().setFfmpegPath(fPath);
 
         if (isRawPcm) {
             fProc = fProc.inputOptions([
@@ -287,30 +253,19 @@ class MediaPlayer extends Media {
         }
 
         fProc = fProc.outputOptions([
-            `-f s16le`,
+            "-f s16le",
             `-ar ${this.SAMPLE_RATE}`,
             `-ac ${this.CHANNELS}`
         ]);
 
-        // Apply loudnorm unless explicitly disabled or the input is already raw PCM.
         const useLoudnorm = isRawPcm ? false
             : (options.loudnorm !== undefined ? options.loudnorm : this.loudnessNormalisation);
-        if (useLoudnorm) {
-            fProc = fProc.audioFilters("loudnorm");
-        }
+        if (useLoudnorm) fProc = fProc.audioFilters("loudnorm");
 
         fProc
-            .on("start", (cli) => {
-                // Keep the start log — it's the only way to see the exact FFmpeg
-                // command line when diagnosing "Invalid data" errors.
-                console.log("[MediaPlayer] FFmpeg started:", cli);
-            })
+            .on("start", (cli) => console.log("[MediaPlayer] FFmpeg started:", cli))
             .on("error", (err) => {
-                this.ffmpegFinished = true;
-                // Suppress errors that come from our own intentional kill() —
-                // when stop()/leave calls #cleanUp() it sends SIGKILL, which
-                // fluent-ffmpeg turns into an "error" event. Without this guard
-                // that bubbles up as an uncaughtException crashing the process.
+                // Suppress intentional kills (stop/leave sends SIGKILL).
                 if (this.stopped) return;
                 const msg = err?.message ?? String(err);
                 if (
@@ -321,41 +276,21 @@ class MediaPlayer extends Media {
                 ) return;
                 this.emit("error", err);
             })
-            .on("codecData", (d) => {
-                this.codecData = d;
-            })
-            .on("end", () => {
-                this.ffmpegFinished = true;
-            });
+            .on("codecData", (d) => { this.codecData = d; })
+            .on("end",       ()  => { /* _processLoop handles completion */ });
 
         this.fProc = fProc;
 
-        // FIX: store the pipe reference so #cleanUp() can destroy it.
+        // Pipe FFmpeg output directly into the VolumeTransformer.
+        // Node.js stream piping handles backpressure: when captureFrame()
+        // blocks, the Transform buffer fills, FFmpeg stdout buffer fills,
+        // and FFmpeg itself throttles — no data accumulates in JS memory.
         const out = fProc.pipe();
         this._ffmpegOut = out;
+        out.pipe(this.volumeTransformer);
 
-        out.on("data", (chunk) => {
-            if (this.stopped) return;
-            this.chunks.push(chunk);
-
-            // BACKPRESSURE: pause FFmpeg output when the buffer is full.
-            // Without this, FFmpeg decodes the entire track into this.chunks
-            // before playback consumes anything.
-            // 100h stream at 48kHz stereo s16le ≈ 64 GB — we cap at ~400 KB.
-            if (this.chunks.length >= MAX_CHUNKS) {
-                try { out.pause(); } catch (_) {}
-            }
-
-            if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
-        });
-        out.on("error", (err) => {
-            this.ffmpegFinished = true;
-            if (!this.stopped) this.emit("error", err);
-        });
-        out.on("end", () => {
-            this.ffmpegFinished = true;
-            if (!this.stopped && this.chunks.length === 0) this.stop();
-        });
+        // Start the async frame loop. Runs concurrently with the pipe.
+        this._processLoop(this.volumeTransformer);
     }
 }
 

--- a/src/Media.js
+++ b/src/Media.js
@@ -4,6 +4,11 @@ const fPath = require("ffmpeg-static");
 const { EventEmitter } = require("events");
 const prism = require("prism-media");
 
+function isIgnorableCaptureError(err) {
+  const msg = err?.message ?? String(err ?? "");
+  return msg.includes("InvalidState") || msg.includes("failed to capture frame") || msg.includes("capture frame");
+}
+
 /**
  * @class
  * @classdesc Basic class to process audio streams. As of 5a2fd7bcde9819c927157a965cfafdb8661f3e4e this doesn't have any functionality anymore and acts more like an interface.
@@ -74,6 +79,8 @@ class MediaPlayer extends Media {
 
 		this.originStream = null;
 		this.fProc = null;
+		this.ffmpegOutput = null;
+		this.stopped = false;
 
 		this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
 		this.volumeTransformer.once("data", () => {
@@ -100,12 +107,16 @@ class MediaPlayer extends Media {
   }
 
 	#cleanUp() {
+		this.stopped = true;
+		this.readyPlayPacket = false;
 		this.originStream?.destroy();
-		if (this.ffmpegFinished) this.fProc.kill(); // "SIGSTOP" to suspend
+		this.ffmpegOutput?.destroy?.();
+		if (this.fProc && !this.ffmpegFinished) this.fProc.kill();
 		this.volumeTransformer.destroy();
 	}
 
 	stop(init=true) {
+		if (this.stopped) return;
 		this.readyPlayPacket = false; // prevent new packets from being played out
 
 		this.#cleanUp();
@@ -148,18 +159,15 @@ class MediaPlayer extends Media {
 		await room.localParticipant.publishTrack(this.track, this.publishOptions);
 	}
 
-  async playOutPacket() {
+	async playOutPacket() {
 		return new Promise((res) => {
+			if (this.stopped) return res();
 			if (this.chunks.length === 0) return res(this.readyPlayPacket = true);
 			this.readyPlayPacket = false;
 
 			const c = this.chunks.shift();
 
 			this.volumeTransformer.once("data", async (chunk) => {
-				// Guard: if stop() was called while waiting for data,
-				// readyPlayPacket is false — discard this chunk silently.
-				if (!this.readyPlayPacket) return res();
-
 				const samples = new Int16Array(
 					chunk.buffer,
 					chunk.byteOffset,
@@ -170,17 +178,16 @@ class MediaPlayer extends Media {
 					this.SAMPLE_RATE,
 					this.CHANNELS,
 					Math.trunc(samples.length / this.CHANNELS)
-				);
+				)
 
 				try {
 					await this.source.captureFrame(frame);
-					this.playedOutSamples += samples.length / this.CHANNELS;
-				} catch (e) {
-					// AudioSource was closed or in InvalidState (track stopped mid-frame).
-					// Discard this frame silently and stop processing further chunks.
-					this.readyPlayPacket = true;
+				} catch (err) {
+					if (this.stopped || isIgnorableCaptureError(err)) return res();
+					this.emit("error", err);
 					return res();
 				}
+				this.playedOutSamples += samples.length / this.CHANNELS;
 
 				if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
 				this.readyPlayPacket = true;
@@ -195,13 +202,13 @@ class MediaPlayer extends Media {
 		this.emit("buffer");
 		this.originStream = stream;
     this.started = false;
+		this.stopped = false;
 
     this.ffmpegFinished = false;
 		this.playedOutSamples = 0;
-    const fProc = ffmpeg(stream)
+    let fProc = ffmpeg(stream)
       .noVideo()
       .setFfmpegPath(fPath)
-      .audioFilters("loudnorm")
       //.native() // TODO: check if necessary
       .outputOptions([
         `-f s16le`,
@@ -213,7 +220,7 @@ class MediaPlayer extends Media {
       })
       .on("error", (err, stdout, stderr) => {
 				this.ffmpegFinished = true;
-        // TODO: error handling
+        this.emit("error", err);
       })
 			.on("codecData", (d) => {
 				this.codecData = d;
@@ -222,11 +229,25 @@ class MediaPlayer extends Media {
         this.ffmpegFinished = true;
 				console.log("ffmpeg finished");
       });
+		if (this.loudnessNormalisation) {
+			fProc = fProc.audioFilters("loudnorm");
+		}
 		this.fProc = fProc;
-    fProc.pipe().on("data", (chunk) => {
+    const out = fProc.pipe();
+		this.ffmpegOutput = out;
+    out.on("data", (chunk) => {
+			if (this.stopped) return;
       this.chunks.push(chunk)
       if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
-    })
+    });
+		out.on("error", (err) => {
+			this.ffmpegFinished = true;
+			if (!this.stopped) this.emit("error", err);
+		});
+		out.on("end", () => {
+			this.ffmpegFinished = true;
+			if (!this.stopped && this.chunks.length === 0) this.stop();
+		});
   }
 }
 

--- a/src/Media.js
+++ b/src/Media.js
@@ -2,305 +2,278 @@ const { AudioSource, LocalAudioTrack, TrackPublishOptions, TrackSource, AudioFra
 const ffmpeg = require("fluent-ffmpeg");
 const fPath = require("ffmpeg-static");
 const { EventEmitter } = require("events");
-const fs = require("fs");
 const prism = require("prism-media");
 
 /**
  * @class
- * @classdesc Basic class to process audio streams.
+ * @classdesc Basic class to process audio streams. As of 5a2fd7bcde9819c927157a965cfafdb8661f3e4e this doesn't have any functionality anymore and acts more like an interface.
  */
 class Media extends EventEmitter {
-    SAMPLE_RATE = 48000;
-    CHANNELS = 2;
-    id = null;
+  SAMPLE_RATE = 48000;
+  CHANNELS = 2;
+  id = null;
 
-    constructor() {
-        super();
-        this.id = Math.random().toString(36) + Date.now();
-        this.source = new AudioSource(this.SAMPLE_RATE, this.CHANNELS);
-        this.track = LocalAudioTrack.createAudioTrack("audio-" + this.id, this.source);
-    }
+  constructor() {
+                super();
 
-    playFile(path) {
-        if (!path) throw "You must specify a file to play!";
-        const stream = fs.createReadStream(path);
-        this.playStream(stream);
-    }
-    playStream(stream) {
-        if (!stream) throw "You must specify a stream to play!";
-        throw "Unsupported. Use MediaPlayer instead.";
-    }
+    this.id = Math.random().toString(36) + Date.now();
+
+    this.source = new AudioSource(this.SAMPLE_RATE, this.CHANNELS);
+    this.track = LocalAudioTrack.createAudioTrack("audio-" + this.id, this.source);
+  }
+
+        playFile(path) {
+                if (!path) throw "You must specify a file to play!";
+                const stream = fs.createReadStream(path);
+                this.playStream(stream);
+        }
+        playStream(stream) {
+                if (!stream) throw "You must specify a stream to play!";
+                throw "Unsupported. Use MediaPlayer instead.";
+        }
 }
 
 /**
  * @class
  * @augments Media
- * @description An advanced version of the Media class with media controls.
+ * @description An advanced version of the Media class. It also includes media controls like pausing and volume adjustment.
  *
- * Pipeline (demand-driven, nothing buffered in JS memory):
- *
- *   FFmpeg stdout (paused/Readable mode)
- *       → one chunk read manually via stream.read()
- *           → VolumeTransformer.write() / read one transformed chunk
- *               → AudioFrame → AudioSource.captureFrame()  (real-time async)
- *                   → loop back and read the next chunk
- *
- * FFmpeg stdout is kept in paused mode. We call .read() only after
- * captureFrame() resolves, so FFmpeg is throttled to exactly playback speed
- * and nothing accumulates in memory regardless of track length.
+ * @property {number} seconds - The amount of seconds passed during playback.
+ * @property {string} currTimestamp - The current timestamp in ffmpeg format `hh:mm:ss`.
  */
 class MediaPlayer extends Media {
-    constructor(normalisation = true) {
-        super();
-        this.isMediaPlayer = true;
-        this.loudnessNormalisation = normalisation;
-        this.initValues();
-    }
+        /**
+         * @description Initiates the MediaPlayer instance.
+         * @param {boolean} normalisation=true Wether to pass the `loudnorm` flag to FFmpeg.
+         *
+         * @return {MediaPlayer}            The new instance.
+         */
+  constructor(normalisation=true) {
+    super();
 
-    initValues() {
-        this.ready            = true;
-        this.volCache         = null;
-        this.paused           = false;
-        this.playing          = false;
-        this.stopped          = false;
-        this.playedOutSamples = 0;
-        this.codecData        = null;
-        this.originStream     = null;
-        this.fProc            = null;
-        this._ffmpegOut       = null;
-        this._unpauseResolve  = null;
+    this.isMediaPlayer = true;
+    this.loudnessNormalisation = normalisation;
+    this.error = null; // should not reset after stop();
 
-        this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
-    }
+    this.initValues();
+  }
 
-    pause() {
-        if (this.paused) return;
-        this.paused = true;
-        this.emit("pause");
-    }
+        initValues() {
+                this.ready = true;
+                this.volCache = null;
 
-    resume() {
-        if (!this.paused) return;
-        this.paused = false;
-        if (this._unpauseResolve) {
-            this._unpauseResolve();
-            this._unpauseResolve = null;
-        }
-        this.emit("unpause");
-    }
+                this.paused = false;
+                this.playing = false;
+    this.started = false;
 
-    setVolume(v = 1) {
-        this.volCache = v;
-        return this.volumeTransformer.setVolume(v);
-    }
+                this.chunks = [];
+                this.ffmpegChunks = [];
+                this.readyPlayPacket = true;
+                this.ffmpegFinished = false;
+                this.playedOutSamples = 0;
+                this.codecData = null;
 
-    _waitForResume() {
-        return new Promise(resolve => { this._unpauseResolve = resolve; });
-    }
+                this.originStream = null;
+                this.fProc = null;
 
-    #cleanUp() {
-        try { this._ffmpegOut?.destroy(); }       catch (_) {}
-        this._ffmpegOut = null;
-        try { this.originStream?.destroy(); }     catch (_) {}
-        if (this.fProc) {
-            try { this.fProc.kill(); }            catch (_) {}
-        }
-        try { this.volumeTransformer.destroy(); } catch (_) {}
-        if (this._unpauseResolve) {
-            this._unpauseResolve();
-            this._unpauseResolve = null;
-        }
-    }
-
-    stop(init = true) {
-        const wasPlaying = !this.stopped;
-        this.stopped = true;
-        this.#cleanUp();
-        if (init) {
-            this.initValues();
-            this.stopped = true; // survive initValues() reset
-        }
-        if (wasPlaying) this.emit("finish");
-    }
-
-    destroy() { return this.stop(false); }
-
-    get duration()        { return this.codecData?.duration || 0; }
-    get seconds()         { return this.playedOutSamples / this.SAMPLE_RATE; }
-    get localAudioTrack() { return this.track; }
-
-    get currTimestamp() {
-        const s   = Math.floor(this.seconds);
-        const h   = Math.floor(s / 3600);
-        const m   = Math.floor((s % 3600) / 60);
-        const sec = s % 60;
-        return [h, m, sec].map(n => String(n).padStart(2, "0")).join(":");
-    }
-
-    get publishOptions() {
-        const options = new TrackPublishOptions();
-        options.source = TrackSource.SOURCE_MICROPHONE;
-        return options;
-    }
-
-    async publishToRoom(room) {
-        await room.localParticipant.publishTrack(this.track, this.publishOptions);
-    }
-
-    /**
-     * Read exactly one chunk from a stream that is in paused mode.
-     * Returns null when the stream ends.
-     */
-    _readChunk(readable) {
-        return new Promise((resolve) => {
-            // Try a synchronous read first — data may already be in the
-            // stream's tiny internal highWaterMark buffer (default 16 KB).
-            const chunk = readable.read();
-            if (chunk !== null) return resolve(chunk);
-
-            // Nothing available yet — wait for the next "readable" event,
-            // which fires when at least one chunk is ready, then read it.
-            const onReadable = () => {
-                cleanup();
-                resolve(readable.read());
-            };
-            const onEnd = () => { cleanup(); resolve(null); };
-            const onClose = () => { cleanup(); resolve(null); };
-            const onError = () => { cleanup(); resolve(null); };
-
-            const cleanup = () => {
-                readable.off("readable", onReadable);
-                readable.off("end",      onEnd);
-                readable.off("close",    onClose);
-                readable.off("error",    onError);
-            };
-
-            readable.once("readable", onReadable);
-            readable.once("end",      onEnd);
-            readable.once("close",    onClose);
-            readable.once("error",    onError);
-        });
-    }
-
-    /**
-     * Write one chunk into the VolumeTransformer and read back the
-     * transformed output synchronously. prism-media's VolumeTransformer
-     * is a synchronous Transform — one write always produces one read.
-     */
-    _transformChunk(chunk) {
-        this.volumeTransformer.write(chunk);
-        return this.volumeTransformer.read();
-    }
-
-    /**
-     * Demand-driven playback loop.
-     *
-     * We keep FFmpeg's output stream in paused (non-flowing) mode and call
-     * .read() only after captureFrame() has returned. This means:
-     *   - FFmpeg stdout OS buffer: at most ~64 KB (kernel default pipe size)
-     *   - VolumeTransformer buffer: at most one chunk (~few KB, highWaterMark)
-     *   - JS heap: nothing stored between iterations
-     *
-     * Total memory per player: ~few KB, regardless of track length.
-     */
-    async _processLoop(out) {
-        // Ensure the stream is in paused mode — we drive reads manually.
-        out.pause();
-
-        let firstChunk = true;
-        while (!this.stopped) {
-            // Pause gate — block here without consuming any data.
-            while (this.paused && !this.stopped) {
-                await this._waitForResume();
-            }
-            if (this.stopped) break;
-
-            const raw = await this._readChunk(out);
-            if (raw === null || this.stopped) break; // stream ended or stopped
-
-            const chunk = this._transformChunk(raw);
-            if (!chunk) continue; // transformer not ready yet (shouldn't happen)
-
-            if (firstChunk) {
-                firstChunk = false;
-                this.playing = true;
-                this.emit("startplay");
-            }
-
-            const samples = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.length / 2);
-            const frame   = new AudioFrame(
-                samples, this.SAMPLE_RATE, this.CHANNELS,
-                Math.trunc(samples.length / this.CHANNELS)
-            );
-
-            // captureFrame is real-time async — it resolves at exactly the
-            // right wall-clock time for the frame. This is what throttles the
-            // entire pipeline: FFmpeg can't produce more data than we consume.
-            await this.source.captureFrame(frame);
-            if (this.stopped) break;
-
-            this.playedOutSamples += samples.length / this.CHANNELS;
+                this.volumeTransformer = new prism.VolumeTransformer({ type: "s16le", volume: 1 });
+                this.volumeTransformer.once("data", () => {
+                        this.playing = true;
+                        this.emit("startplay");
+                })
         }
 
-        if (!this.stopped) this.stop();
-    }
+  pause() {
+    if (this.paused) return;
+    this.paused = true;
 
-    async playStream(stream, options = {}) {
-        this.emit("buffer");
-        this.originStream     = stream;
-        this.stopped          = false;
-        this.playing          = false;
-        this.playedOutSamples = 0;
+    this.emit("pause");
+  }
+  resume() {
+    if (!this.paused) return;
+    this.paused = false;
 
-        const isRawPcm = options.rawPcm === true;
+    if (this.readyPlayPacket) this.playOutPacket();
+    this.emit("unpause");
+  }
+  setVolume(v=1) {
+    return this.volumeTransformer.setVolume(v);
+  }
 
-        let fProc = ffmpeg(stream).noVideo().setFfmpegPath(fPath);
-
-        if (isRawPcm) {
-            fProc = fProc.inputOptions([
-                "-f s16le",
-                `-ar ${this.SAMPLE_RATE}`,
-                `-ac ${this.CHANNELS}`
-            ]);
+        #cleanUp() {
+                this.originStream?.destroy();
+                if (this.ffmpegFinished) this.fProc.kill(); // "SIGSTOP" to suspend
+                this.volumeTransformer.destroy();
         }
 
-        fProc = fProc.outputOptions([
-            "-f s16le",
-            `-ar ${this.SAMPLE_RATE}`,
-            `-ac ${this.CHANNELS}`
-        ]);
+        stop(init=true) {
+                this.readyPlayPacket = false; // prevent new packets from being played out
 
-        const useLoudnorm = isRawPcm ? false
-            : (options.loudnorm !== undefined ? options.loudnorm : this.loudnessNormalisation);
-        if (useLoudnorm) fProc = fProc.audioFilters("loudnorm");
+                this.#cleanUp();
 
-        fProc
-            .on("start",    (cli) => console.log("[MediaPlayer] FFmpeg started:", cli))
-            .on("error",    (err) => {
-                if (this.stopped) return;
-                const msg = err?.message ?? String(err);
-                if (
-                    msg.includes("SIGKILL")            ||
-                    msg.includes("killed with signal") ||
-                    msg.includes("aborted")            ||
-                    msg.includes("Input stream error")
-                ) return;
-                this.emit("error", err);
-            })
-            .on("codecData", (d) => { this.codecData = d; })
-            .on("end",       ()  => { /* _processLoop drives completion */ });
+                if (init) this.initValues();
 
-        this.fProc = fProc;
+                this.emit("finish");
+        }
+        destroy() {
+                return this.stop(false);
+        }
 
-        // Get the output stream and immediately switch it to paused mode
-        // so _processLoop controls every read.
-        const out = fProc.pipe();
-        this._ffmpegOut = out;
+        get duration() {
+                return this.codecData?.duration || 0;
+        }
+        get currTimestamp() {
+                const sec_num = this.seconds();
+                var hours = Math.floor(sec_num / 3600);
+                var minutes = Math.floor((sec_num - (hours * 3600)) / 60);
+                var seconds = sec_num - (hours * 3600) - (minutes * 60);
 
-        // Drive playback. _processLoop keeps out in paused mode and only
-        // calls .read() after each captureFrame() — true demand-driven I/O.
-        this._processLoop(out);
+                if (hours < 10) { hours = "0" + hours; }
+                if (minutes < 10) { minutes = "0" + minutes; }
+                if (seconds < 10) { seconds = "0" + seconds; }
+                return hours + ':' + minutes + ':' + seconds;
+        }
+        get seconds() {
+                return this.playedOutSamples / this.SAMPLE_RATE;
+        }
+
+  get localAudioTrack() {
+    return this.track;
+  }
+  get publishOptions() {
+    const options = new TrackPublishOptions();
+    options.source = TrackSource.SOURCE_MICROPHONE;
+    return options;
+  }
+        async publishToRoom(room) {
+                await room.localParticipant.publishTrack(this.track, this.publishOptions);
+        }
+
+  async playOutPacket() {
+                return new Promise((res) => {
+                        if (this.chunks.length === 0) return res(this.readyPlayPacket = true);
+                        this.readyPlayPacket = false;
+
+                        const c = this.chunks.shift();
+
+                        this.volumeTransformer.once("data", async (chunk) => {
+                                const samples = new Int16Array(
+                                        chunk.buffer,
+                                        chunk.byteOffset,
+                                        chunk.length / 2 // chunk.length is in bytes
+                                );
+                                const frame = new AudioFrame(
+                                        samples,
+                                        this.SAMPLE_RATE,
+                                        this.CHANNELS,
+                                        Math.trunc(samples.length / this.CHANNELS)
+                                )
+
+                                await this.source.captureFrame(frame);
+                                this.playedOutSamples += samples.length / this.CHANNELS;
+
+                                if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
+                                this.readyPlayPacket = true;
+                                if (this.chunks.length === 0 && this.ffmpegFinished) this.stop();
+                                return res();
+                        });
+                        this.volumeTransformer.write(c);
+                });
+  }
+
+  /**
+   * Play an audio stream through FFmpeg and publish to the LiveKit room.
+   *
+   * @param {ReadableStream} stream              The audio stream to play.
+   * @param {String[]|Object} [inputOptions=[]]  FFmpeg input options.
+   *   - If an **array**, passed directly as fluent-ffmpeg input options
+   *     (backward-compatible with upstream API).
+   *   - If an **object**, the following keys are recognised:
+   *     - `rawPcm` {boolean}  — prepend raw PCM format flags
+   *       (`-f s16le -ar 48000 -ac 2`) to the input options.
+   *     - `audioFilter` {string} — FFmpeg audio filter chain applied
+   *       after loudnorm (replaces it when rawPcm is true).
+   *     - `inputOptions` {String[]} — additional input options appended
+   *       after the raw PCM flags (if any).
+   */
+  async playStream(stream, inputOptions=[]) {
+                this.emit("buffer");
+                this.originStream = stream;
+    this.started = false;
+
+    this.ffmpegFinished = false;
+                this.playedOutSamples = 0;
+
+    // ── Normalise the 2nd parameter ──────────────────────────────────────
+    let rawInputOpts = [];
+    let audioFilter  = "";
+    let isRawPcm     = false;
+
+    if (Array.isArray(inputOptions)) {
+      // Legacy upstream API: playStream(stream, ["-f s16le", "-ar 48000"])
+      rawInputOpts = inputOptions;
+    } else if (inputOptions && typeof inputOptions === "object") {
+      isRawPcm     = !!inputOptions.rawPcm;
+      audioFilter  = inputOptions.audioFilter || "";
+      rawInputOpts = Array.isArray(inputOptions.inputOptions)
+          ? inputOptions.inputOptions
+          : [];
     }
+
+    // ── Build final input options (prepend raw PCM flags if needed) ──────
+    const finalInputOpts = [];
+    if (isRawPcm) {
+      finalInputOpts.push("-f", "s16le", "-ar", String(this.SAMPLE_RATE), "-ac", String(this.CHANNELS));
+    }
+    finalInputOpts.push(...rawInputOpts);
+
+    // ── Build audio filter chain ─────────────────────────────────────────
+    const afParts = [];
+    if (!isRawPcm && this.loudnessNormalisation) {
+      afParts.push("loudnorm");
+    }
+    if (audioFilter) {
+      afParts.push(audioFilter);
+    }
+
+    // ── Assemble fluent-ffmpeg command ───────────────────────────────────
+    const fProc = ffmpeg(stream)
+      .noVideo()
+      .setFfmpegPath(fPath)
+      .inputOptions(finalInputOpts);
+
+    if (afParts.length > 0) {
+      fProc.audioFilters(afParts.join(","));
+    }
+
+    fProc
+      .outputOptions([
+        `-f s16le`,
+        `-ar ${this.SAMPLE_RATE}`,
+        `-ac ${this.CHANNELS}`
+      ])
+      .on("start", (cli) => {
+        console.log(`[MediaPlayer] FFmpeg started: ${cli}`)
+      })
+      .on("error", (err, stdout, stderr) => {
+        this.ffmpegFinished = true;
+        // TODO: error handling
+        this.error = err;
+        this.stop();
+      })
+                        .on("codecData", (d) => {
+                                this.codecData = d;
+                        })
+      .on("end", () => {
+        this.ffmpegFinished = true;
+                                console.log("ffmpeg finished");
+      });
+                this.fProc = fProc;
+    fProc.pipe().on("data", (chunk) => {
+      this.chunks.push(chunk)
+      if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
+    })
+  }
 }
 
-module.exports = { MediaPlayer, Media };
+module.exports = { MediaPlayer, Media }

--- a/src/Media.js
+++ b/src/Media.js
@@ -143,17 +143,28 @@ class MediaPlayer extends Media {
     }
 
     stop(init = true) {
-        // Guard: if already stopped, don't re-emit "finish". Without this, the
-        // unconditional mediaPlayer.stop() call at the top of _doPlayNext fires
-        // a second "finish" event on an already-stopped player, which resolves
-        // the _streamViaRevoice promise for the *next* song before it plays
-        // a single frame — causing every song after the first to be skipped.
-        if (this.stopped && init) return;
+        // Only emit "finish" if we were actually in a playing state.
+        // _doPlayNext calls stop() at the top of every song transition to ensure
+        // cleanup — but if the song already ended naturally, stop() was already
+        // called internally, and a second "finish" would resolve _streamViaRevoice's
+        // once("finish") listener for the *next* song before it starts, causing
+        // every song after the first to be immediately skipped.
+        const wasPlaying = !this.stopped;
+
         this.stopped = true;
-        this.readyPlayPacket = false; // prevent new packets from being queued
+        this.readyPlayPacket = false;
         this.#cleanUp();
-        if (init) this.initValues();
-        this.emit("finish");
+
+        if (init) {
+            this.initValues();
+            // initValues() resets stopped→false (player is ready for reuse).
+            // Keep stopped=true until playStream() is called so any redundant
+            // stop() calls between song transitions don't re-emit "finish".
+            this.stopped = true;
+        }
+
+        // Only fire "finish" once per actual playback session.
+        if (wasPlaying) this.emit("finish");
     }
 
     destroy() {
@@ -251,6 +262,9 @@ class MediaPlayer extends Media {
         this.emit("buffer");
         this.originStream = stream;
         this.started = false;
+        // Mark as live — stop() sets stopped=true after initValues() so that
+        // redundant stop() calls between song transitions don't re-emit "finish".
+        // playStream() is the authoritative signal that playback has started.
         this.stopped = false;
         this.ffmpegFinished = false;
         this.playedOutSamples = 0;

--- a/src/Media.js
+++ b/src/Media.js
@@ -5,6 +5,18 @@ const { EventEmitter } = require("events");
 const fs = require("fs"); // FIX: was missing — playFile() would crash with ReferenceError
 const prism = require("prism-media");
 
+// ---------------------------------------------------------------------------
+// Backpressure constants
+//
+// FFmpeg decodes audio far faster than real-time. Without a cap every player
+// buffers the entire decoded track — a 100h stream is ~64 GB of s16le PCM.
+//
+// At ~4 KB per chunk, MAX_CHUNKS=100 keeps the buffer under ~400 KB (~2 s of
+// audio) per player regardless of track length.
+// ---------------------------------------------------------------------------
+const MAX_CHUNKS    = 100; // pause FFmpeg output when buffer reaches this size
+const RESUME_CHUNKS =  40; // resume FFmpeg output once buffer drains this low
+
 /**
  * @class
  * @classdesc Basic class to process audio streams.
@@ -85,12 +97,19 @@ class MediaPlayer extends Media {
 	pause() {
 		if (this.paused) return;
 		this.paused = true;
+		// Also pause the FFmpeg output so we stop accumulating chunks while
+		// playback is suspended — without this the buffer keeps growing.
+		try { this._ffmpegOut?.pause(); } catch (_) {}
 		this.emit("pause");
 	}
 
 	resume() {
 		if (!this.paused) return;
 		this.paused = false;
+		// Only resume FFmpeg output if the buffer has room.
+		if (this.chunks.length < RESUME_CHUNKS) {
+			try { this._ffmpegOut?.resume(); } catch (_) {}
+		}
 		if (this.readyPlayPacket) this.playOutPacket();
 		this.emit("unpause");
 	}
@@ -200,6 +219,17 @@ class MediaPlayer extends Media {
 				await this.source.captureFrame(frame);
 				this.playedOutSamples += samples.length / this.CHANNELS;
 
+				// BACKPRESSURE: resume FFmpeg output when the buffer drains
+				// below the low-water mark so it can refill the ~400 KB window.
+				if (
+					this._ffmpegOut &&
+					!this.paused &&
+					!this.ffmpegFinished &&
+					this.chunks.length < RESUME_CHUNKS
+				) {
+					try { this._ffmpegOut.resume(); } catch (_) {}
+				}
+
 				if (this.chunks.length > 0 && !this.paused) return res(this.playOutPacket());
 				this.readyPlayPacket = true;
 				if (this.chunks.length === 0 && this.ffmpegFinished) this.stop();
@@ -257,8 +287,19 @@ class MediaPlayer extends Media {
 			})
 			.on("error", (err) => {
 				this.ffmpegFinished = true;
-				// Propagate the error so Player.mjs can handle it.
-				if (!this.stopped) this.emit("error", err);
+				// Suppress errors that come from our own intentional kill() —
+				// when stop()/leave calls #cleanUp() it sends SIGKILL, which
+				// fluent-ffmpeg turns into an "error" event. Without this guard
+				// that bubbles up as an uncaughtException crashing the process.
+				if (this.stopped) return;
+				const msg = err?.message ?? String(err);
+				if (
+					msg.includes("SIGKILL") ||
+					msg.includes("killed with signal") ||
+					msg.includes("aborted") ||
+					msg.includes("Input stream error")
+				) return;
+				this.emit("error", err);
 			})
 			.on("codecData", (d) => {
 				this.codecData = d;
@@ -276,6 +317,15 @@ class MediaPlayer extends Media {
 		out.on("data", (chunk) => {
 			if (this.stopped) return;
 			this.chunks.push(chunk);
+
+			// BACKPRESSURE: pause FFmpeg output when the buffer is full.
+			// Without this, FFmpeg decodes the entire track into this.chunks
+			// before playback consumes anything.
+			// 100h stream at 48kHz stereo s16le ≈ 64 GB — we cap at ~400 KB.
+			if (this.chunks.length >= MAX_CHUNKS) {
+				try { out.pause(); } catch (_) {}
+			}
+
 			if (this.readyPlayPacket && !this.paused) return this.playOutPacket();
 		});
 		out.on("error", (err) => {


### PR DESCRIPTION
- Added readyPlayPacket guard at the start of the VolumeTransformer data handler — if stop() was called while waiting for data, the chunk is discarded silently instead of being processed
- Wrapped source.captureFrame() in try/catch to handle InvalidState errors when the AudioSource is closed mid-frame (e.g. track stopped or connection dropped during playback)
- Previously these errors were unhandled promises that crashed the global unhandledRejection handler with: 'RtcError: InvalidState - failed to capture frame

```
1|fluxer   | Error: an RtcError occured: InvalidState - failed to capture frame
1|fluxer   |     at AudioSource.captureFrame (/root/fluxer/node_modules/@livekit/rtc-node/dist/audio_source.cjs:117:13)
1|fluxer   |     at async VolumeTransformer.<anonymous> (/root/fluxer/node_modules/revoice.js/src/Media.js:171:5)
1|fluxer   | [2026-04-12 15:03:18] [Error_Handling] Unhandled Rejection/Catch
1|fluxer   | [2026-04-12 15:03:18] Reason: Error: an RtcError occured: InvalidState - failed to capture frame
1|fluxer   |     at AudioSource.captureFrame (/root/fluxer/node_modules/@livekit/rtc-node/dist/audio_source.cjs:117:13)
1|fluxer   |     at async VolumeTransformer.<anonymous> (/root/fluxer/node_modules/revoice.js/src/Media.js:171:5) Promise {
1|fluxer   |   <rejected> Error: an RtcError occured: InvalidState - failed to capture frame
1|fluxer   |       at AudioSource.captureFrame (/root/fluxer/node_modules/@livekit/rtc-node/dist/audio_source.cjs:117:13)
1|fluxer   |       at async VolumeTransformer.<anonymous> (/root/fluxer/node_modules/revoice.js/src/Media.js:171:5)
1|fluxer   | }
```